### PR TITLE
Verbiage updates

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -29,11 +29,25 @@ return array(
         ),
     ),
     'zf-mvc-auth' => array(
-        // Toggle the following to true to change the ACL creation to require an
-        // authenticated user by default, and thus selectively allow unauthenticated
-        // users based on the rules.
-        'deny_by_default' => false,
-        'rules' => array(
+        'authentication' => array(
+            /**
+             *
+            'http' => array(
+                'accept_schemes' => array('basic', 'digest'),
+                'realm' => 'My Web Site',
+                'digest_domains' => '/',
+                'nonce_timeout' => 3600,
+                'htpasswd' => APPLICATION_PATH . '/data/htpasswd' // htpasswd tool generated
+                'htdigest' => APPLICATION_PATH . '/data/htdigest' // @see http://www.askapache.com/online-tools/htpasswd-generator/
+            ),
+             */
+        ),
+        'authorization' => array(
+            // Toggle the following to true to change the ACL creation to 
+            // require an authenticated user by default, and thus selectively 
+            // allow unauthenticated users based on the rules.
+            'deny_by_default' => false,
+
             /*
              * Rules indicating what controllers are behind authentication.
              *
@@ -74,21 +88,6 @@ return array(
                 ),
             ),
              */
-        ),
-        'authentication' => array(
-            /**
-             *
-            'http' => array(
-                'accept_schemes' => array('basic', 'digest'),
-                'realm' => 'My Web Site',
-                'digest_domains' => '/',
-                'nonce_timeout' => 3600,
-                'htpasswd' => APPLICATION_PATH . '/data/htpasswd' // htpasswd tool generated
-                'htdigest' => APPLICATION_PATH . '/data/htdigest' // @see http://www.askapache.com/online-tools/htpasswd-generator/
-            ),
-             */
-        ),
-        'authorization' => array(
         ),
     ),
 );

--- a/src/ZF/MvcAuth/Authorization/AclAuthorizationFactory.php
+++ b/src/ZF/MvcAuth/Authorization/AclAuthorizationFactory.php
@@ -38,8 +38,8 @@ abstract class AclAuthorizationFactory
             $acl->addResource($set['resource']);
 
             // Deny guest specified privileges to resource
-            $rights = isset($set['rights']) ? $set['rights'] : null;
-            $acl->$grant('guest', $resource, $rights);
+            $privileges = isset($set['privileges']) ? $set['privileges'] : null;
+            $acl->$grant('guest', $resource, $privileges);
         }
 
         return $acl;

--- a/src/ZF/MvcAuth/Factory/AclAuthorizationFactory.php
+++ b/src/ZF/MvcAuth/Factory/AclAuthorizationFactory.php
@@ -44,7 +44,7 @@ class AclAuthorizationFactory implements FactoryInterface
     }
 
     /**
-     * Generate the ACL instance based on the zf-mc-auth "rules" configuration
+     * Generate the ACL instance based on the zf-mc-auth "authorization" configuration
      *
      * Consumes the AclFactory in order to create the AclAuthorization instance.
      *
@@ -56,18 +56,17 @@ class AclAuthorizationFactory implements FactoryInterface
         $aclConfig = array();
 
         if (isset($config['zf-mvc-auth'])
-            && isset($config['zf-mvc-auth']['deny_by_default'])
-            && $config['zf-mvc-auth']['deny_by_default']
+            && isset($config['zf-mvc-auth']['authorization'])
         ) {
-            $aclConfig['deny_by_default'] = true;
-        }
+            $config = $config['zf-mvc-auth']['authorization'];
 
-        if (isset($config['zf-mvc-auth'])
-            && isset($config['zf-mvc-auth']['rules'])
-        ) {
-            $rulesConfig = $config['zf-mvc-auth']['rules'];
-            foreach ($rulesConfig as $controllerService => $rules) {
-                $this->createAclConfigFromRules($controllerService, $rules, $aclConfig);
+            if (array_key_exists('deny_by_default', $config)) {
+                $aclConfig['deny_by_default'] = (bool) $config['deny_by_default'];
+                unset($config['deny_by_default']);
+            }
+            
+            foreach ($config as $controllerService => $privileges) {
+                $this->createAclConfigFromPrivileges($controllerService, $privileges, $aclConfig);
             }
         }
 
@@ -75,70 +74,70 @@ class AclAuthorizationFactory implements FactoryInterface
     }
 
     /**
-     * Creates ACL configuration based on the rules configured
+     * Creates ACL configuration based on the privileges configured
      *
-     * - Extracts a rule per action
-     * - Extracts rules for each of "collection" and "resource" configured
+     * - Extracts a privilege per action
+     * - Extracts privileges for each of "collection" and "resource" configured
      *
      * @param string $controllerService
-     * @param array $rules
+     * @param array $privileges
      * @param array $aclConfig
      */
-    protected function createAclConfigFromRules($controllerService, array $rules, &$aclConfig)
+    protected function createAclConfigFromPrivileges($controllerService, array $privileges, &$aclConfig)
     {
-        if (isset($rules['actions'])) {
-            foreach ($rules['actions'] as $action => $methods) {
+        if (isset($privileges['actions'])) {
+            foreach ($privileges['actions'] as $action => $methods) {
                 $aclConfig[] = array(
-                    'resource' => sprintf('%s::%s', $controllerService, $action),
-                    'rights'   => $this->createRightsFromMethods($methods),
+                    'resource'   => sprintf('%s::%s', $controllerService, $action),
+                    'privileges' => $this->createPrivilegesFromMethods($methods),
                 );
             }
         }
 
-        if (isset($rules['collection'])) {
+        if (isset($privileges['collection'])) {
             $aclConfig[] = array(
-                'resource' => sprintf('%s::collection', $controllerService),
-                'rights'   => $this->createRightsFromMethods($rules['collection']),
+                'resource'   => sprintf('%s::collection', $controllerService),
+                'privileges' => $this->createPrivilegesFromMethods($privileges['collection']),
             );
         }
 
-        if (isset($rules['resource'])) {
+        if (isset($privileges['resource'])) {
             $aclConfig[] = array(
-                'resource' => sprintf('%s::resource', $controllerService),
-                'rights'   => $this->createRightsFromMethods($rules['resource']),
+                'resource'   => sprintf('%s::resource', $controllerService),
+                'privileges' => $this->createPrivilegesFromMethods($privileges['resource']),
             );
         }
     }
 
     /**
-     * Create the list of HTTP methods defining rights
+     * Create the list of HTTP methods defining privileges
      *
      * @param array $methods
      * @return array|null
      */
-    protected function createRightsFromMethods(array $methods)
+    protected function createPrivilegesFromMethods(array $methods)
     {
-        $rights = array();
+        $privileges = array();
 
         if (isset($methods['default']) && $methods['default']) {
-            $rights = $this->httpMethods;
+            $privileges = $this->httpMethods;
             unset($methods['default']);
         }
 
         foreach ($methods as $method => $flag) {
             if (!$flag) {
-                if (isset($rights[$method])) {
-                    unset($rights[$method]);
+                if (isset($privileges[$method])) {
+                    unset($privileges[$method]);
                 }
                 continue;
             }
-            $rights[$method] = true;
+            $privileges[$method] = true;
         }
 
-        if (empty($rights)) {
+        if (empty($privileges)) {
             return null;
         }
 
-        return array_keys($rights);
+        return array_keys($privileges);
     }
 }

--- a/test/ZFTest/MvcAuth/Authorization/AclAuthorizationFactoryTest.php
+++ b/test/ZFTest/MvcAuth/Authorization/AclAuthorizationFactoryTest.php
@@ -12,15 +12,15 @@ class AclAuthorizationFactoryTest extends TestCase
         $config = array(
             array(
                 'resource' => 'ZendCon\V1\Rest\Session\Controller::collection',
-                'rights' => array('POST'),
+                'privileges' => array('POST'),
             ),
             array(
                 'resource' => 'ZendCon\V1\Rest\Session\Controller::resource',
-                'rights' => array('PATCH', 'DELETE'),
+                'privileges' => array('PATCH', 'DELETE'),
             ),
             array(
                 'resource' => 'ZendCon\V1\Rpc\Message\Controller::message',
-                'rights' => array('POST'),
+                'privileges' => array('POST'),
             ),
         );
 
@@ -59,15 +59,15 @@ class AclAuthorizationFactoryTest extends TestCase
             'deny_by_default' => true,
             array(
                 'resource' => 'ZendCon\V1\Rest\Session\Controller::collection',
-                'rights' => array('GET'),
+                'privileges' => array('GET'),
             ),
             array(
                 'resource' => 'ZendCon\V1\Rest\Session\Controller::resource',
-                'rights' => array('GET'),
+                'privileges' => array('GET'),
             ),
             array(
                 'resource' => 'ZendCon\V1\Rpc\Message\Controller::message',
-                'rights' => array('GET'),
+                'privileges' => array('GET'),
             ),
         );
 


### PR DESCRIPTION
Updates verbiage in the configuration and code:
- "rules" and "rights" become "privileges" to keep consistent with ACL and RBAC verbiage
- "rules" configuration becomes "authorization", and the `deny_by_default` key is moved inside the `authorization` configuration now
