### PR TITLE
Allow apps specified custom `Zend\Authentication\Adapter\Http\ResolverInterface`

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -14,6 +14,7 @@ return array(
         'factories' => array(
             'ZF\MvcAuth\Authentication' => 'ZF\MvcAuth\Factory\AuthenticationServiceFactory',
             'ZF\MvcAuth\Authentication\DefaultAuthenticationListener' => 'ZF\MvcAuth\Factory\DefaultAuthenticationListenerFactory',
+            'ZF\MvcAuth\Authentication\AuthHttpAdapter' => 'ZF\MvcAuth\Factory\DefaultAuthHttpAdapterFactory',
             'ZF\MvcAuth\Authorization\AclAuthorization' => 'ZF\MvcAuth\Factory\AclAuthorizationFactory',
             'ZF\MvcAuth\Authorization\DefaultAuthorizationListener' => 'ZF\MvcAuth\Factory\DefaultAuthorizationListenerFactory',
             'ZF\MvcAuth\Authorization\DefaultResourceResolverListener' => 'ZF\MvcAuth\Factory\DefaultResourceResolverListenerFactory',
@@ -43,8 +44,8 @@ return array(
              */
         ),
         'authorization' => array(
-            // Toggle the following to true to change the ACL creation to 
-            // require an authenticated user by default, and thus selectively 
+            // Toggle the following to true to change the ACL creation to
+            // require an authenticated user by default, and thus selectively
             // allow unauthenticated users based on the rules.
             'deny_by_default' => false,
 
@@ -62,7 +63,7 @@ return array(
              * Method values are arrays of HTTP method/boolean pairs. By
              * default, if an HTTP method is not present in the list, it is
              * assumed to be open (i.e., not require authentication). The
-             * special key "default" can be used to set the default flag for 
+             * special key "default" can be used to set the default flag for
              * all HTTP methods.
              *
             'Controller\Service\Name' => array(

--- a/src/ZF/MvcAuth/Factory/DefaultAuthHttpAdapterFactory.php
+++ b/src/ZF/MvcAuth/Factory/DefaultAuthHttpAdapterFactory.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2013 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\MvcAuth\Factory;
+
+use Zend\Authentication\Adapter\Http as HttpAuth;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Factory for creating the DefaultAuthHttpAdapterFactory from configuration
+ */
+class DefaultAuthHttpAdapterFactory implements FactoryInterface
+{
+    /**
+     * @param ServiceLocatorInterface $services
+     * @throws ServiceNotCreatedException
+     * @return HttpAuthAdapter
+     */
+    public function createService(ServiceLocatorInterface $services)
+    {
+        $config = $services->get('config');
+        if (isset($config['zf-mvc-auth']['authentication']['http'])) {
+            $httpConfig = $config['zf-mvc-auth']['authentication']['http'];
+        }
+        else {
+            return false;
+        }
+
+        if (!isset($httpConfig['accept_schemes']) || !is_array($httpConfig['accept_schemes'])) {
+            throw new ServiceNotCreatedException('accept_schemes is required when configuring an HTTP authentication adapter');
+        }
+
+        if (!isset($httpConfig['realm'])) {
+            throw new ServiceNotCreatedException('realm is required when configuring an HTTP authentication adapter');
+        }
+
+        if (in_array('digest', $httpConfig['accept_schemes'])) {
+            if (!isset($httpConfig['digest_domains'])
+                || !isset($httpConfig['nonce_timeout'])
+            ) {
+                throw new ServiceNotCreatedException('Both digest_domains and nonce_timeout are required when configuring an HTTP digest authentication adapter');
+            }
+        }
+
+        return new HttpAuth(array_merge($httpConfig, array('accept_schemes' => implode(' ', $httpConfig['accept_schemes']))));
+    }
+}


### PR DESCRIPTION
Now apps can specified its own resolver providing a custom 'ZF\MvcAuth\Authentication\AuthHttpAdapter' factory.

Developers can inherited from `ZF\MvcAuth\Factory\DefaultAuthHttpAdapterFactory` and call `setDigestResolver` and `setBasicResolver` methods to specified theirs own resolver.

Configured file resolver still have precedence.
