### PR TITLE
Allow stateful Auth

### DIFF
--- a/src/ZF/MvcAuth/Authentication/DefaultAuthenticationListener.php
+++ b/src/ZF/MvcAuth/Authentication/DefaultAuthenticationListener.php
@@ -98,6 +98,14 @@ class DefaultAuthenticationListener
                 }
 
                 $auth   = $mvcAuthEvent->getAuthenticationService();
+                if ($auth->hasIdentity()) {
+                    $identity = $auth->getIdentity();
+                    if (!$identity instanceof Identity\AuthenticatedIdentity) {
+                        $identity = new Identity\AuthenticatedIdentity($identity);
+                    }
+                    return $identity;
+                }
+
                 $result = $auth->authenticate($this->httpAdapter);
                 $mvcAuthEvent->setAuthenticationResult($result);
 


### PR DESCRIPTION
This patch not change current out of the box behavior, it just allow Apigility users opt to stateful Auth.

A way to do that is providing a replacement to the 'ZF\MvcAuth\Authentication' service's factory (`AuthenticationServiceFactory`) to use as storage something different than `NonPersistent`.

Stateful auth is conceptually against RESTful principles, but come in handy in some environments. That is why I think we should allow Apigility users decide about.
