### PR TITLE
Added support for roles

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -32,7 +32,6 @@ return array(
     'zf-mvc-auth' => array(
         'authentication' => array(
             /**
-             *
             'http' => array(
                 'accept_schemes' => array('basic', 'digest'),
                 'realm' => 'My Web Site',
@@ -50,9 +49,11 @@ return array(
             'deny_by_default' => false,
 
             /*
-             * Rules indicating what controllers are behind authentication.
+             * Rules indicating what controllers are behind authentication,
+             * specified per role.
              *
-             * Keys are controller service names.
+             * First-lever keys indicate the role, second level keys
+             * are controller service names.
              *
              * Values are arrays with either the key "actions" and/or one or
              * more of the keys "collection" and "resource".
@@ -66,26 +67,28 @@ return array(
              * special key "default" can be used to set the default flag for
              * all HTTP methods.
              *
-            'Controller\Service\Name' => array(
-                'actions' => array(
-                    'action' => array(
+            'admin' => array(
+                'Controller\Service\Name' => array(
+                    'actions' => array(
+                        'action' => array(
+                            'default' => boolean,
+                            'GET' => boolean,
+                            'POST' => boolean,
+                            // etc.
+                        ),
+                    ),
+                    'collection' => array(
                         'default' => boolean,
                         'GET' => boolean,
                         'POST' => boolean,
                         // etc.
                     ),
-                ),
-                'collection' => array(
-                    'default' => boolean,
-                    'GET' => boolean,
-                    'POST' => boolean,
-                    // etc.
-                ),
-                'resource' => array(
-                    'default' => boolean,
-                    'GET' => boolean,
-                    'POST' => boolean,
-                    // etc.
+                    'resource' => array(
+                        'default' => boolean,
+                        'GET' => boolean,
+                        'POST' => boolean,
+                        // etc.
+                    ),
                 ),
             ),
              */

--- a/src/ZF/MvcAuth/Factory/AclAuthorizationFactory.php
+++ b/src/ZF/MvcAuth/Factory/AclAuthorizationFactory.php
@@ -65,8 +65,10 @@ class AclAuthorizationFactory implements FactoryInterface
                 unset($config['deny_by_default']);
             }
 
-            foreach ($config as $controllerService => $privileges) {
-                $this->createAclConfigFromPrivileges($controllerService, $privileges, $aclConfig);
+            foreach ($config as $role => $controllerConfig) {
+                foreach ($controllerConfig as $controllerService => $privileges) {
+                    $this->createAclConfigFromPrivileges($controllerService, $privileges, $role, $aclConfig);
+                }
             }
         }
 
@@ -81,15 +83,17 @@ class AclAuthorizationFactory implements FactoryInterface
      *
      * @param string $controllerService
      * @param array $privileges
+     * @param string $role
      * @param array $aclConfig
      */
-    protected function createAclConfigFromPrivileges($controllerService, array $privileges, &$aclConfig)
+    protected function createAclConfigFromPrivileges($controllerService, array $privileges, $role, &$aclConfig)
     {
         if (isset($privileges['actions'])) {
             foreach ($privileges['actions'] as $action => $methods) {
                 $aclConfig[] = array(
                     'resource'   => sprintf('%s::%s', $controllerService, $action),
                     'privileges' => $this->createPrivilegesFromMethods($methods),
+                    'role' => $role
                 );
             }
         }
@@ -98,6 +102,7 @@ class AclAuthorizationFactory implements FactoryInterface
             $aclConfig[] = array(
                 'resource'   => sprintf('%s::collection', $controllerService),
                 'privileges' => $this->createPrivilegesFromMethods($privileges['collection']),
+                'role' => $role
             );
         }
 
@@ -105,6 +110,7 @@ class AclAuthorizationFactory implements FactoryInterface
             $aclConfig[] = array(
                 'resource'   => sprintf('%s::resource', $controllerService),
                 'privileges' => $this->createPrivilegesFromMethods($privileges['resource']),
+                'role' => $role
             );
         }
     }

--- a/test/ZFTest/MvcAuth/Factory/AclAuthorizationFactoryTest.php
+++ b/test/ZFTest/MvcAuth/Factory/AclAuthorizationFactoryTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * AclAuthorizationFactoryTest
+ *
+ * @category  AcsiApiTest\MvcAuth\Factory
+ * @package   AcsiApiTest\MvcAuth\Factory
+ * @copyright 2014 ACSI Holding bv (http://www.acsi.eu)
+ * @version   SVN: $Id$
+ */
+namespace AcsiApiTest\MvcAuth\Factory;
+
+use Zf\MvcAuth\Factory\AclAuthorizationFactory;
+use ZF\MvcAuth\Authorization\AclAuthorization;
+
+class AclAuthorizationFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var  AclAuthorizationFactory */
+    protected $factory;
+
+    public function setUp()
+    {
+        $this->factory = new AclAuthorizationFactory();
+    }
+
+    public function testIfServiceCorrectlyCreated()
+    {
+        $config = array(
+            'zf-mvc-auth' => array(
+                'authorization' => array(
+                    'deny_by_default' => true,
+                    'guest' => array(
+                        'TestController' => array(
+                            'resource' => array(
+                                'default' => false,
+                                'GET' => true
+                            ),
+                            'collection' => array(
+                                'default' => false,
+                            ),
+                            'actions' => array(
+                                'index' => array(
+                                    'default' => false,
+                                    'GET' => true
+                                ),
+                            ),
+                        ),
+                        'TestController2' => array(
+                            'resource' => array(
+                                'default' => true,
+                            ),
+                            'actions' => array(
+                                'index' => array(
+                                    'default' => false,
+                                ),
+                            ),
+                        ),
+                    ),
+                    'admin' => array(
+                        'TestController' => array(
+                            'resource' => array(
+                                'default' => true,
+                            ),
+                            'actions' => array(
+                                'index' => array(
+                                    'default' => false,
+                                    'GET' => true
+                                ),
+                            ),
+                        ),
+                        'TestController2' => array(
+                            'resource' => array(
+                                'default' => true,
+                            ),
+                            'actions' => array(
+                                'index' => array(
+                                    'default' => true,
+                                ),
+                            ),
+                        ),
+                    ),
+                )
+            )
+        );
+
+        $serviceManager = \Mockery::mock('Zend\ServiceManager\ServiceLocatorInterface');
+        $serviceManager->shouldReceive('has')->with('config')->andReturn(true)->getMock();
+        $serviceManager->shouldReceive('get')->with('config')->andReturn($config)->getMock();
+
+        /** @var AclAuthorization $acl */
+        $acl = $this->factory->createService($serviceManager);
+
+        $this->assertTrue($acl->isAllowed('guest', 'TestController::index', 'GET'));
+        $this->assertTrue($acl->isAllowed('guest', 'TestController::resource', 'GET'));
+        $this->assertFalse($acl->isAllowed('guest', 'TestController::collection', 'GET'));
+        $this->assertFalse($acl->isAllowed('guest', 'TestController2::index', 'GET'));
+        $this->assertTrue($acl->isAllowed('guest', 'TestController2::resource', 'GET'));
+
+        $this->assertTrue($acl->isAllowed('admin', 'TestController::index', 'GET'));
+        $this->assertTrue($acl->isAllowed('admin', 'TestController::resource', 'GET'));
+        $this->assertFalse($acl->isAllowed('admin', 'TestController::index', 'POST'));
+        $this->assertFalse($acl->isAllowed('admin', 'TestController::collection', 'GET'));
+        $this->assertTrue($acl->isAllowed('admin', 'TestController2::index', 'GET'));
+        $this->assertTrue($acl->isAllowed('admin', 'TestController2::resource', 'GET'));
+    }
+}


### PR DESCRIPTION
Added the ability to use roles in ZfMvcAuth. The config syntax changed a
little. Now you have to specify the role name, which contain the old config syntax.

For example:

``` php
'admin' => array(
    'Controller\Service\Name' => array(
        'actions' => array(
            'action' => array(
                'default' => boolean,
                'GET' => boolean,
                'POST' => boolean,
                // etc.
            ),
        ),
    ),
)
```
