### PR TITLE
api-identity is seeded with an Identity. GuestIdentity is used if the us...

### DIFF
--- a/src/ZF/MvcAuth/Authentication/DefaultAuthenticationListener.php
+++ b/src/ZF/MvcAuth/Authentication/DefaultAuthenticationListener.php
@@ -61,9 +61,7 @@ class DefaultAuthenticationListener
         $request  = $mvcEvent->getRequest();
         $response = $mvcEvent->getResponse();
 
-        if (!$request instanceof HttpRequest
-            || $request->isOptions()
-        ) {
+        if (!$request instanceof HttpRequest) {
             return;
         }
 
@@ -77,14 +75,14 @@ class DefaultAuthenticationListener
             if ($this->httpAdapter instanceof HttpAuth) {
                 $this->httpAdapter->challengeClient();
             }
-            return;
+            return new Identity\GuestIdentity();
         }
 
         $headerContent = trim($authHeader->getFieldValue());
 
         // we only support headers in the format: Authorization: xxx yyyyy
         if (strpos($headerContent, ' ') === false) {
-            return;
+            return new Identity\GuestIdentity();
         }
 
         list($type, $credential) = preg_split('# #', $headerContent, 2);
@@ -94,7 +92,7 @@ class DefaultAuthenticationListener
             case 'digest':
 
                 if (!$this->httpAdapter instanceof HttpAuth) {
-                    return;
+                    return new Identity\GuestIdentity();
                 }
 
                 $auth   = $mvcAuthEvent->getAuthenticationService();
@@ -114,7 +112,7 @@ class DefaultAuthenticationListener
             case 'bearer':
 
                 if (!$this->oauth2Server instanceof OAuth2Server) {
-                    return;
+                    return new Identity\GuestIdentity();
                 }
 
                 $content       = $request->getContent();

--- a/src/ZF/MvcAuth/MvcRouteListener.php
+++ b/src/ZF/MvcAuth/MvcRouteListener.php
@@ -70,9 +70,7 @@ class MvcRouteListener extends AbstractListenerAggregate
      */
     public function authentication(MvcEvent $mvcEvent)
     {
-        if (!$mvcEvent->getRequest() instanceof HttpRequest
-            || $mvcEvent->getRequest()->isOptions()
-        ) {
+        if (!$mvcEvent->getRequest() instanceof HttpRequest) {
             return;
         }
 
@@ -139,9 +137,7 @@ class MvcRouteListener extends AbstractListenerAggregate
      */
     public function authenticationPost(MvcEvent $mvcEvent)
     {
-        if (!$mvcEvent->getRequest() instanceof HttpRequest
-            || $mvcEvent->getRequest()->isOptions()
-        ) {
+        if (!$mvcEvent->getRequest() instanceof HttpRequest) {
             return;
         }
 

--- a/test/ZFTest/MvcAuth/Authentication/DefaultAuthenticationListenerTest.php
+++ b/test/ZFTest/MvcAuth/Authentication/DefaultAuthenticationListenerTest.php
@@ -117,6 +117,23 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->assertEquals('user', $identity->getRoleId());
     }
 
+    public function testInvokeForBasicAuthSetsGuestIdentityWhenValid()
+    {
+        $httpAuth = new HttpAuth(array(
+            'accept_schemes' => 'basic',
+            'realm' => 'My Web Site',
+            'digest_domains' => '/',
+            'nonce_timeout' => 3600,
+        ));
+        $httpAuth->setBasicResolver(new HttpAuth\ApacheResolver(__DIR__ . '/../TestAsset/htpasswd'));
+        $this->listener->setHttpAdapter($httpAuth);
+
+        $this->request->getHeaders()->addHeaderLine('Authorization: Basic xxxxxxxxx');
+        $identity = $this->listener->__invoke($this->mvcAuthEvent);
+        $this->assertInstanceOf('ZF\MvcAuth\Identity\GuestIdentity', $identity);
+        $this->assertEquals('guest', $identity->getRoleId());
+    }
+
     public function testInvokeForBasicAuthHasNoIdentityWhenNotValid()
     {
         $httpAuth = new HttpAuth(array(


### PR DESCRIPTION
The api-identity service is seeded with an Identity. GuestIdentity is used if the user is not authenticated.

Was requested by @weierophinney to create a pull-request as per: https://groups.google.com/a/zend.com/forum/#!topic/apigility-users/QOUNCLeY62s

I imagine I've done something wrong, so feel free to slap me in the right direction if anything is wrong. 
