### PR TITLE
deny_by_default inverts permission rules

### DIFF
--- a/src/Authorization/AclAuthorizationFactory.php
+++ b/src/Authorization/AclAuthorizationFactory.php
@@ -12,7 +12,7 @@ abstract class AclAuthorizationFactory
     {
         // Determine whether we are whitelisting or blacklisting
         $denyByDefault = false;
-        if (isset($config['deny_by_default'])) {
+        if (array_key_exists('deny_by_default', $config)) {
             $denyByDefault = (bool) $config['deny_by_default'];
             unset($config['deny_by_default']);
         }
@@ -29,7 +29,7 @@ abstract class AclAuthorizationFactory
         }
 
         foreach ($config as $set) {
-            if (!is_array($set) || !isset($set['resource'])) {
+            if (! is_array($set) || ! isset($set['resource'])) {
                 continue;
             }
 

--- a/test/Factory/AclAuthorizationFactoryTest.php
+++ b/test/Factory/AclAuthorizationFactoryTest.php
@@ -18,7 +18,7 @@ class AclAuthorizationFactoryTest extends TestCase
         $this->factory  = new AclAuthorizationFactory();
     }
 
-    public function testCreatingOAuth2ServerFromStorageService()
+    public function testCanCreateWhitelistAcl()
     {
         $config = array('zf-mvc-auth' => array('authorization' => array(
             'Foo\Bar\RestController' => array(
@@ -80,5 +80,126 @@ class AclAuthorizationFactoryTest extends TestCase
                     break;
             }
         }
+    }
+
+    public function testBlacklistAclSpecificationHonorsBooleansSetForMethods()
+    {
+        $config = array('zf-mvc-auth' => array('authorization' => array(
+            'deny_by_default' => true,
+            'Foo\Bar\RestController' => array(
+                'entity' => array(
+                    'GET'    => false,
+                    'POST'   => false,
+                    'PUT'    => true,
+                    'PATCH'  => true,
+                    'DELETE' => true,
+                ),
+                'collection' => array(
+                    'GET'    => false,
+                    'POST'   => true,
+                    'PUT'    => false,
+                    'PATCH'  => false,
+                    'DELETE' => false,
+                ),
+            ),
+            'Foo\Bar\RpcController' => array(
+                'actions' => array(
+                    'do' => array(
+                        'GET'    => false,
+                        'POST'   => true,
+                        'PUT'    => false,
+                        'PATCH'  => false,
+                        'DELETE' => false,
+                    ),
+                ),
+            ),
+        )));
+        $this->services->setService('config', $config);
+
+        $acl = $this->factory->createService($this->services);
+
+        $this->assertInstanceOf('ZF\MvcAuth\Authorization\AclAuthorization', $acl);
+
+        $authorizations = $config['zf-mvc-auth']['authorization'];
+        unset($authorizations['deny_by_default']);
+
+        foreach ($authorizations as $resource => $rules) {
+            switch (true) {
+                case (array_key_exists('entity', $rules)):
+                    foreach ($rules['entity'] as $method => $expected) {
+                        $assertion = 'assert' . ($expected ? 'False' : 'True');
+                        $this->$assertion($acl->isAllowed('guest', $resource . '::entity', $method));
+                    }
+                case (array_key_exists('collection', $rules)):
+                    foreach ($rules['collection'] as $method => $expected) {
+                        $assertion = 'assert' . ($expected ? 'False' : 'True');
+                        $this->$assertion($acl->isAllowed('guest', $resource . '::collection', $method));
+                    }
+                    break;
+                case (array_key_exists('actions', $rules)):
+                    foreach ($rules['actions'] as $action => $actionRules) {
+                        foreach ($actionRules as $method => $expected) {
+                            $assertion = 'assert' . ($expected ? 'False' : 'True');
+                            $this->$assertion($acl->isAllowed('guest', $resource . '::' . $action, $method));
+                        }
+                    }
+                    break;
+            }
+        }
+    }
+
+    public function testBlacklistAclsDenyByDefaultForUnspecifiedHttpMethods()
+    {
+        $config = array('zf-mvc-auth' => array('authorization' => array(
+            'deny_by_default' => true,
+            'Foo\Bar\RestController' => array(
+                'entity' => array(
+                    'GET'    => false,
+                    'POST'   => false,
+                ),
+                'collection' => array(
+                    'GET'    => false,
+                    'PUT'    => false,
+                    'PATCH'  => false,
+                    'DELETE' => false,
+                ),
+            ),
+            'Foo\Bar\RpcController' => array(
+                'actions' => array(
+                    'do' => array(
+                        'GET'    => false,
+                        'PUT'    => false,
+                        'PATCH'  => false,
+                        'DELETE' => false,
+                    ),
+                ),
+            ),
+        )));
+        $this->services->setService('config', $config);
+
+        $acl = $this->factory->createService($this->services);
+
+        $this->assertInstanceOf('ZF\MvcAuth\Authorization\AclAuthorization', $acl);
+
+        $authorizations = $config['zf-mvc-auth']['authorization'];
+        unset($authorizations['deny_by_default']);
+
+        $this->assertFalse($acl->isAllowed('guest', 'Foo\Bar\RestController::entity', 'PATCH'));
+        $this->assertFalse($acl->isAllowed('guest', 'Foo\Bar\RestController::entity', 'PUT'));
+        $this->assertFalse($acl->isAllowed('guest', 'Foo\Bar\RestController::entity', 'DELETE'));
+        $this->assertTrue($acl->isAllowed('guest', 'Foo\Bar\RestController::entity', 'GET'));
+        $this->assertTrue($acl->isAllowed('guest', 'Foo\Bar\RestController::entity', 'POST'));
+
+        $this->assertFalse($acl->isAllowed('guest', 'Foo\Bar\RestController::collection', 'POST'));
+        $this->assertTrue($acl->isAllowed('guest', 'Foo\Bar\RestController::collection', 'GET'));
+        $this->assertTrue($acl->isAllowed('guest', 'Foo\Bar\RestController::collection', 'PATCH'));
+        $this->assertTrue($acl->isAllowed('guest', 'Foo\Bar\RestController::collection', 'PUT'));
+        $this->assertTrue($acl->isAllowed('guest', 'Foo\Bar\RestController::collection', 'DELETE'));
+
+        $this->assertFalse($acl->isAllowed('guest', 'Foo\Bar\RpcController::do', 'POST'));
+        $this->assertTrue($acl->isAllowed('guest', 'Foo\Bar\RpcController::do', 'GET'));
+        $this->assertTrue($acl->isAllowed('guest', 'Foo\Bar\RpcController::do', 'PUT'));
+        $this->assertTrue($acl->isAllowed('guest', 'Foo\Bar\RpcController::do', 'PATCH'));
+        $this->assertTrue($acl->isAllowed('guest', 'Foo\Bar\RpcController::do', 'DELETE'));
     }
 }


### PR DESCRIPTION
When I set `deny_by_default` to true, zf-mvc-auth seems to invert the meaning of my permission rules:

`module.config.php`:

``` php
    'zf-mvc-auth' => array(
        'authorization' => array(
            'deny_by_default' => true,
            'Api\\V1\\Rest\\User\\Controller' => array(
                'entity' => array(
                    'GET' => true, // Don't need authorization?
                    'POST' => false,
                    'PATCH' => false,
                    'PUT' => false,
                    'DELETE' => false,
                ),
            ),
```

According to the documentation, the boolean value of GET determines whether or not authorization is required. However, when `deny_by_default` is `true`, suddenly the booleans are interpreted to mean that authorization is _not_ required.

The documentation says that `deny_by_default` only changes behavior for actions for which no permission was defined, but in fact it inverts the existing permissions.

https://apigility.org/documentation/modules/zf-mvc-auth
