### PR TITLE
Added a way to configure the resolver class to use for basic/digest auth

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -26,17 +26,18 @@ return array(
     ),
     'zf-mvc-auth' => array(
         'authentication' => array(
-            /**
-             *
             'http' => array(
+                'basic_resolver_class'  => '\\Zend\\Authentication\\Adapter\\Http\\ApacheResolver',
+                'digest_resolver_class' => '\\Zend\\Authentication\\Adapter\\Http\\FileResolver',
+                /**
                 'accept_schemes' => array('basic', 'digest'),
                 'realm' => 'My Web Site',
                 'digest_domains' => '/',
                 'nonce_timeout' => 3600,
-                'htpasswd' => APPLICATION_PATH . '/data/htpasswd' // htpasswd tool generated
-                'htdigest' => APPLICATION_PATH . '/data/htdigest' // @see http://www.askapache.com/online-tools/htpasswd-generator/
+                'htpasswd' => APPLICATION_PATH . '/data/htpasswd', // htpasswd tool generated
+                'htdigest' => APPLICATION_PATH . '/data/htdigest', // @see http://www.askapache.com/online-tools/htpasswd-generator/
+                 */
             ),
-             */
         ),
         'authorization' => array(
             // Toggle the following to true to change the ACL creation to

--- a/src/Factory/DefaultAuthHttpAdapterFactory.php
+++ b/src/Factory/DefaultAuthHttpAdapterFactory.php
@@ -61,11 +61,13 @@ class DefaultAuthHttpAdapterFactory implements FactoryInterface
         ));
 
         if (in_array('basic', $httpConfig['accept_schemes']) && isset($httpConfig['htpasswd'])) {
-            $httpAdapter->setBasicResolver(new HttpAuth\ApacheResolver($httpConfig['htpasswd']));
+            $basicResolverClass = $httpConfig['basic_resolver_class'];
+            $httpAdapter->setBasicResolver(new $basicResolverClass($httpConfig['htpasswd']));
         }
 
         if (in_array('digest', $httpConfig['accept_schemes']) && isset($httpConfig['htdigest'])) {
-            $httpAdapter->setDigestResolver(new HttpAuth\FileResolver($httpConfig['htdigest']));
+            $digestResolverClass = $httpConfig['digest_resolver_class'];
+            $httpAdapter->setDigestResolver(new $digestResolverClass($httpConfig['htdigest']));
         }
 
         return $httpAdapter;

--- a/test/Authentication/DefaultAuthenticationListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationListenerTest.php
@@ -86,6 +86,8 @@ class DefaultAuthenticationListenerTest extends TestCase
     public function testInvokeForBasicAuthAddsAuthorizationHeader()
     {
         $httpAuth = new HttpAuth(array(
+            'basic_resolver_class'  => '\\Zend\\Authentication\\Adapter\\Http\\ApacheResolver',
+            'digest_resolver_class' => '\\Zend\\Authentication\\Adapter\\Http\\FileResolver',
             'accept_schemes' => 'basic',
             'realm' => 'My Web Site',
             'digest_domains' => '/',
@@ -104,6 +106,8 @@ class DefaultAuthenticationListenerTest extends TestCase
     public function testInvokeForBasicAuthSetsIdentityWhenValid()
     {
         $httpAuth = new HttpAuth(array(
+            'basic_resolver_class'  => '\\Zend\\Authentication\\Adapter\\Http\\ApacheResolver',
+            'digest_resolver_class' => '\\Zend\\Authentication\\Adapter\\Http\\FileResolver',
             'accept_schemes' => 'basic',
             'realm' => 'My Web Site',
             'digest_domains' => '/',
@@ -122,6 +126,8 @@ class DefaultAuthenticationListenerTest extends TestCase
     public function testInvokeForBasicAuthSetsGuestIdentityWhenValid()
     {
         $httpAuth = new HttpAuth(array(
+            'basic_resolver_class'  => '\\Zend\\Authentication\\Adapter\\Http\\ApacheResolver',
+            'digest_resolver_class' => '\\Zend\\Authentication\\Adapter\\Http\\FileResolver',
             'accept_schemes' => 'basic',
             'realm' => 'My Web Site',
             'digest_domains' => '/',
@@ -140,6 +146,8 @@ class DefaultAuthenticationListenerTest extends TestCase
     public function testInvokeForBasicAuthHasNoIdentityWhenNotValid()
     {
         $httpAuth = new HttpAuth(array(
+            'basic_resolver_class'  => '\\Zend\\Authentication\\Adapter\\Http\\ApacheResolver',
+            'digest_resolver_class' => '\\Zend\\Authentication\\Adapter\\Http\\FileResolver',
             'accept_schemes' => 'basic',
             'realm' => 'My Web Site',
             'digest_domains' => '/',
@@ -156,6 +164,8 @@ class DefaultAuthenticationListenerTest extends TestCase
     public function testInvokeForDigestAuthAddsAuthorizationHeader()
     {
         $httpAuth = new HttpAuth(array(
+            'basic_resolver_class'  => '\\Zend\\Authentication\\Adapter\\Http\\ApacheResolver',
+            'digest_resolver_class' => '\\Zend\\Authentication\\Adapter\\Http\\FileResolver',
             'accept_schemes' => 'digest',
             'realm' => 'User Area',
             'digest_domains' => '/',

--- a/test/Factory/DefaultAuthenticationListenerFactoryTest.php
+++ b/test/Factory/DefaultAuthenticationListenerFactoryTest.php
@@ -79,6 +79,8 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
             'zf-mvc-auth' => array(
                 'authentication' => array(
                     'http' => array(
+                        'basic_resolver_class'  => '\\Zend\\Authentication\\Adapter\\Http\\ApacheResolver',
+                        'digest_resolver_class' => '\\Zend\\Authentication\\Adapter\\Http\\FileResolver',
                         'accept_schemes' => array('basic'),
                         'realm' => 'test',
                     ),
@@ -96,6 +98,8 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
             'zf-mvc-auth' => array(
                 'authentication' => array(
                     'http' => array(
+                        'basic_resolver_class'  => '\\Zend\\Authentication\\Adapter\\Http\\ApacheResolver',
+                        'digest_resolver_class' => '\\Zend\\Authentication\\Adapter\\Http\\FileResolver',
                         'accept_schemes' => array('digest'),
                         'realm' => 'test',
                         'digest_domains' => '/',
@@ -115,6 +119,8 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
             'zf-mvc-auth' => array(
                 'authentication' => array(
                     'http' => array(
+                        'basic_resolver_class'  => '\\Zend\\Authentication\\Adapter\\Http\\ApacheResolver',
+                        'digest_resolver_class' => '\\Zend\\Authentication\\Adapter\\Http\\FileResolver',
                         'accept_schemes' => array('basic'),
                         'realm' => 'My Web Site',
                         'digest_domains' => '/',
@@ -135,6 +141,8 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
             'zf-mvc-auth' => array(
                 'authentication' => array(
                     'http' => array(
+                        'basic_resolver_class'  => '\\Zend\\Authentication\\Adapter\\Http\\ApacheResolver',
+                        'digest_resolver_class' => '\\Zend\\Authentication\\Adapter\\Http\\FileResolver',
                         'accept_schemes' => array('digest'),
                         'realm' => 'User Area',
                         'digest_domains' => '/',


### PR DESCRIPTION
This PR allows to use a personalized resolver for basic/digest authentication
