### PR TITLE
Code cleaning

### DIFF
--- a/src/Authorization/DefaultAuthorizationListener.php
+++ b/src/Authorization/DefaultAuthorizationListener.php
@@ -9,7 +9,6 @@ namespace ZF\MvcAuth\Authorization;
 use Zend\Http\Request;
 use Zend\Http\Response;
 use Zend\Mvc\Router\RouteMatch;
-use Zend\Permissions\Acl\Acl;
 use ZF\MvcAuth\MvcAuthEvent;
 use ZF\MvcAuth\Identity\IdentityInterface;
 
@@ -21,20 +20,11 @@ class DefaultAuthorizationListener
     protected $authorization;
 
     /**
-     * Array of controller_service_name/identifier_name pairs
-     *
-     * @var array
-     */
-    protected $restControllers;
-
-    /**
      * @param AuthorizationInterface $authorization
-     * @param array $restControllers
      */
-    public function __construct(AuthorizationInterface $authorization, array $restControllers = array())
+    public function __construct(AuthorizationInterface $authorization)
     {
-        $this->authorization   = $authorization;
-        $this->restControllers = $restControllers;
+        $this->authorization = $authorization;
     }
 
     /**

--- a/src/Authorization/DefaultResourceResolverListener.php
+++ b/src/Authorization/DefaultResourceResolverListener.php
@@ -17,6 +17,9 @@ class DefaultResourceResolverListener
      */
     protected $restControllers;
 
+    /**
+     * @param array $restControllers
+     */
     public function __construct(array $restControllers = array())
     {
         $this->restControllers = $restControllers;

--- a/src/MvcAuthEvent.php
+++ b/src/MvcAuthEvent.php
@@ -18,8 +18,14 @@ class MvcAuthEvent extends Event
     const EVENT_AUTHORIZATION = 'authorization';
     const EVENT_AUTHORIZATION_POST = 'authorization.post';
 
+    /**
+     * @var MvcEvent
+     */
     protected $mvcEvent;
 
+    /**
+     * @var mixed
+     */
     protected $authentication;
 
     /**
@@ -27,6 +33,9 @@ class MvcAuthEvent extends Event
      */
     protected $authenticationResult = null;
 
+    /**
+     * @var mixed
+     */
     protected $authorization;
 
     /**
@@ -42,26 +51,38 @@ class MvcAuthEvent extends Event
      */
     protected $resource;
 
+    /**
+     * @param MvcEvent $mvcEvent
+     * @param mixed    $authentication
+     * @param mixed    $authorization
+     */
     public function __construct(MvcEvent $mvcEvent, $authentication, $authorization)
     {
-        $this->mvcEvent = $mvcEvent;
+        $this->mvcEvent       = $mvcEvent;
         $this->authentication = $authentication;
-        $this->authorization = $authorization;
+        $this->authorization  = $authorization;
     }
 
     /**
-     * @return \Zend\Authentication\AuthenticationService
+     * @return mixed
      */
     public function getAuthenticationService()
     {
         return $this->authentication;
     }
 
+    /**
+     * @return bool
+     */
     public function hasAuthenticationResult()
     {
         return ($this->authenticationResult !== null);
     }
 
+    /**
+     * @param  Result $result
+     * @return self
+     */
     public function setAuthenticationResult(Result $result)
     {
         $this->authenticationResult = $result;
@@ -76,43 +97,70 @@ class MvcAuthEvent extends Event
         return $this->authenticationResult;
     }
 
+    /**
+     * @return mixed
+     */
     public function getAuthorizationService()
     {
         return $this->authorization;
     }
 
+    /**
+     * @return MvcEvent
+     */
     public function getMvcEvent()
     {
         return $this->mvcEvent;
     }
 
+    /**
+     * @return mixed|null
+     */
     public function getIdentity()
     {
         return $this->authentication->getIdentity();
     }
 
+    /**
+     * @param IdentityInterface $identity
+     * @return $this
+     */
     public function setIdentity(IdentityInterface $identity)
     {
         $this->authentication->getStorage()->write($identity);
         return $this;
     }
 
+    /**
+     * @return mixed
+     */
     public function getResource()
     {
         return $this->resource;
     }
 
+    /**
+     * @param  mixed $resource
+     * @return self
+     */
     public function setResource($resource)
     {
         $this->resource = $resource;
         return $this;
     }
 
+    /**
+     * @return bool
+     */
     public function isAuthorized()
     {
         return $this->authorized;
     }
 
+    /**
+     * @param  bool $flag
+     * @return self
+     */
     public function setIsAuthorized($flag)
     {
         $this->authorized = (bool) $flag;


### PR DESCRIPTION
@weierophinney I'd like to take the opportunity to note that the api of the `MvcAuthEvent` is a bit confusing. `setIdentity()` assumes a concrete `Zend\Authentication\AuthenticationService` instance is composed, but the if we add the typehint the tests will fail because an invalid mock is used. Also it is not clear what `$authorization` can be. I've found myself using expecting an `ZF\MvcAuth\Authorization\AuthorizationInterface` and instead it was a `Zend\Permissions\Acl\Acl`.

I know that these problems all involve BC breaks, but I'd really like to have a more consistent API throughout the whole module: it has some rough edges and working with it has not been the most pleasant of the tasks. :-P

Could you give me some insights on what would you change?