### PR TITLE
inject missing headers into OAuth2Request

### DIFF
--- a/src/Authentication/DefaultAuthenticationListener.php
+++ b/src/Authentication/DefaultAuthenticationListener.php
@@ -169,7 +169,17 @@ class DefaultAuthenticationListener
                 }
 
                 $content       = $request->getContent();
-                $oauth2request = new OAuth2Request($_GET, $_POST, array(), $_COOKIE, $_FILES, $_SERVER, $content);
+                $headers       = $request->getHeaders()->toArray();
+                $oauth2request = new OAuth2Request(
+                    $_GET,
+                    $_POST,
+                    array(),
+                    $_COOKIE,
+                    $_FILES,
+                    $_SERVER,
+                    $content,
+                    $headers
+                );
 
                 if ($this->oauth2Server->verifyResourceRequest($oauth2request)) {
                     $token    = $this->oauth2Server->getAccessTokenData($oauth2request);

--- a/test/Authentication/DefaultAuthenticationListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationListenerTest.php
@@ -7,6 +7,7 @@
 namespace ZFTest\MvcAuth\Authentication;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use OAuth2\Request as OAuth2Request;
 use Zend\Authentication\Adapter\Http as HttpAuth;
 use Zend\Authentication\AuthenticationService;
 use Zend\Authentication\Result as AuthenticationResult;
@@ -315,5 +316,23 @@ class DefaultAuthenticationListenerTest extends TestCase
         self::assertEquals($token['user_id'], $identity->getRoleId());
         self::assertEquals($token, $identity->getAuthenticationIdentity());
 
+    }
+
+    public function testOauth2RequestIncludesHeaders()
+    {
+        $this->request->getHeaders()->addHeaderLine('Authorization', 'Bearer TOKEN');
+
+        $server = $this->getMockBuilder('OAuth2\Server')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $server->expects($this->atLeastOnce())
+            ->method('verifyResourceRequest')
+            ->with($this->callback(function (OAuth2Request $request) {
+                return $request->headers('Authorization') === 'Bearer TOKEN';
+            }));
+
+        $this->listener->setOauth2Server($server);
+        $this->listener->__invoke($this->mvcAuthEvent);
     }
 }


### PR DESCRIPTION
I spotted this problem while doing some integration tests: `OAuth2\Request` was not being correctly initialized because its [internal initialization](https://github.com/bshaffer/oauth2-server-php/blob/develop/src/OAuth2/Request.php#L63) relies on `$_SERVER['HTTP_*']` vars.

I noted also that `ZF\OAuth2\Controller\AuthController` does some additional marshalling for the HTTP authentication, but I'm not sure it's needed here, could you confirm that?