### PR TITLE
Implement per-API authentication

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -47,10 +47,13 @@ return array(
                 'htdigest' => APPLICATION_PATH . '/data/htdigest' // @see http://www.askapache.com/online-tools/htpasswd-generator/
             ),
              *
-             * Next, we also have a "map", which maps an API module to a given
-             * configuration type:
+             * Next, we also have a "map", which maps an API module (with
+             * optional version) to a given authentication type (one of basic,
+             * digest, or oauth2):
             'map' => array(
-                'ApiModuleName' => 'http|oauth2',
+                'ApiModuleName' => 'oauth2',
+                'OtherApi\V2' => 'basic',
+                'AnotherApi\V1' => 'digest',
             ),
              */
         ),

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -33,7 +33,10 @@ return array(
     ),
     'zf-mvc-auth' => array(
         'authentication' => array(
-            /**
+            /* First, we define authentication configuration types. These have
+             * the keys:
+             * - http
+             * - oauth2
              *
             'http' => array(
                 'accept_schemes' => array('basic', 'digest'),
@@ -42,6 +45,12 @@ return array(
                 'nonce_timeout' => 3600,
                 'htpasswd' => APPLICATION_PATH . '/data/htpasswd' // htpasswd tool generated
                 'htdigest' => APPLICATION_PATH . '/data/htdigest' // @see http://www.askapache.com/online-tools/htpasswd-generator/
+            ),
+             *
+             * Next, we also have a "map", which maps an API module to a given
+             * configuration type:
+            'map' => array(
+                'ApiModuleName' => 'http|oauth2',
             ),
              */
         ),

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -55,6 +55,16 @@ return array(
                 'OtherApi\V2' => 'basic',
                 'AnotherApi\V1' => 'digest',
             ),
+             *
+             * We also allow you to specify custom authentication types that you
+             * support via listeners; by adding them to the configuration, you
+             * ensure that they will be available for mapping modules to
+             * authentication types in the Admin.
+            'types' => array(
+                'token',
+                'key',
+                'etc',
+            )
              */
         ),
         'authorization' => array(

--- a/src/Authentication/AbstractAdapter.php
+++ b/src/Authentication/AbstractAdapter.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\MvcAuth\Authentication;
+
+use Zend\Http\Request;
+
+abstract class AbstractAdapter implements AdapterInterface
+{
+    /**
+     * Determine if the incoming request provides either basic or digest
+     * credentials
+     *
+     * @param Request $request
+     * @return false|string
+     */
+    public function getTypeFromRequest(Request $request)
+    {
+        $headers = $request->getHeaders();
+        $authorization = $request->getHeader('Authorization');
+        if (! $authorization) {
+            return false;
+        }
+
+        $authorization = trim($authorization->getFieldValue());
+        $type = $this->getTypeFromAuthorizationHeader($authorization);
+
+        if (! in_array($type, $this->provides())) {
+            return false;
+        }
+
+        return $type;
+    }
+
+    /**
+     * Determine the authentication type from the authorization header contents
+     *
+     * @param string $header
+     * @return false|string
+     */
+    private function getTypeFromAuthorizationHeader($header)
+    {
+        // we only support headers in the format: Authorization: xxx yyyyy
+        if (strpos($header, ' ') === false) {
+            return false;
+        }
+
+        list($type, $credential) = preg_split('# #', $header, 2);
+
+        return strtolower($type);
+    }
+}

--- a/src/Authentication/AdapterInterface.php
+++ b/src/Authentication/AdapterInterface.php
@@ -9,6 +9,7 @@ namespace ZF\MvcAuth\Authentication;
 use Zend\Http\Request;
 use Zend\Http\Response;
 use ZF\MvcAuth\Identity\IdentityInterface;
+use ZF\MvcAuth\MvcAuthEvent;
 
 interface AdapterInterface
 {
@@ -44,8 +45,9 @@ interface AdapterInterface
      *
      * @param Request $request
      * @param Response $response
+     * @param MvcAuthEvent $mvcAuthEvent
      * @return false|IdentityInterface False on failure, IdentityInterface
      *     otherwise
      */
-    public function authenticate(Request $request, Response $response);
+    public function authenticate(Request $request, Response $response, MvcAuthEvent $mvcAuthEvent);
 }

--- a/src/Authentication/AdapterInterface.php
+++ b/src/Authentication/AdapterInterface.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\MvcAuth\Authentication;
+
+use Zend\Http\Request;
+use Zend\Http\Response;
+use ZF\MvcAuth\Identity\IdentityInterface;
+
+interface AdapterInterface
+{
+    /**
+     * @return array Array of types this adapter can handle.
+     */
+    public function provides();
+
+    /**
+     * Attempt to retrieve the authentication type based on the request.
+     *
+     * Allows an adapter to have custom logic for detecting if a request
+     * might be providing credentials it's interested in.
+     *
+     * @param Request $request
+     * @return false|string
+     */
+    public function getTypeFromRequest(Request $request);
+
+    /**
+     * Perform pre-flight authentication operations.
+     *
+     * Use case would be for providing authentication challenge headers.
+     *
+     * @param Request $request
+     * @param Response $response
+     * @return void|Response
+     */
+    public function preAuth(Request $request, Response $response);
+
+    /**
+     * Attempt to authenticate the current request.
+     *
+     * @param Request $request
+     * @param Response $response
+     * @return false|IdentityInterface False on failure, IdentityInterface
+     *     otherwise
+     */
+    public function authenticate(Request $request, Response $response);
+}

--- a/src/Authentication/DefaultAuthenticationListener.php
+++ b/src/Authentication/DefaultAuthenticationListener.php
@@ -65,6 +65,25 @@ class DefaultAuthenticationListener
     }
 
     /**
+     * Add custom authentication types.
+     *
+     * This method allows specifiying additional authentication types, outside
+     * of adapters, that your application supports. The values provided are
+     * merged with any types already discovered.
+     * 
+     * @param array $types 
+     */
+    public function addAuthenticationTypes(array $types)
+    {
+        $this->authenticationTypes = array_unique(
+            array_merge(
+                $this->authenticationTypes,
+                $types
+            )
+        );
+    }
+
+    /**
      * Retrieve the supported authentication types
      * 
      * @return array

--- a/src/Authentication/DefaultAuthenticationListener.php
+++ b/src/Authentication/DefaultAuthenticationListener.php
@@ -110,7 +110,7 @@ class DefaultAuthenticationListener
         }
 
         $type = $type ?: $this->getTypeFromRequest($request);
-        if ($type === false) {
+        if (false === $type) {
             if ($this->httpAdapter instanceof HttpAuth) {
                 $this->httpAdapter->setRequest($request);
                 $this->httpAdapter->setResponse($response);

--- a/src/Authentication/DefaultAuthenticationListener.php
+++ b/src/Authentication/DefaultAuthenticationListener.php
@@ -6,15 +6,24 @@
 
 namespace ZF\MvcAuth\Authentication;
 
+use OAuth2\Request as OAuth2Request;
+use OAuth2\Server as OAuth2Server;
+use RuntimeException;
 use Zend\Authentication\Adapter\Http as HttpAuth;
+use Zend\Mvc\Router\RouteMatch;
 use Zend\Http\Request as HttpRequest;
 use ZF\MvcAuth\Identity;
 use ZF\MvcAuth\MvcAuthEvent;
-use OAuth2\Server as OAuth2Server;
-use OAuth2\Request as OAuth2Request;
 
 class DefaultAuthenticationListener
 {
+    /**
+     * Map of API/version to authentication type pairs
+     * 
+     * @var array
+     */
+    private $authMap = array();
+
     /**
      * @var HttpAuth
      */
@@ -61,6 +70,16 @@ class DefaultAuthenticationListener
     }
 
     /**
+     * Set the API/version to authentication type map.
+     * 
+     * @param array $map 
+     */
+    public function setAuthMap(array $map)
+    {
+        $this->authMap = $map;
+    }
+
+    /**
      * Listen to the authentication event
      *
      * @param MvcAuthEvent $mvcAuthEvent
@@ -78,42 +97,23 @@ class DefaultAuthenticationListener
             return;
         }
 
-        $type = false;
-
-        if ($this->httpAdapter instanceof HttpAuth) {
-            $this->httpAdapter->setRequest($request);
-            $this->httpAdapter->setResponse($response);
-        }
-
-        $authHeader = $request->getHeader('Authorization');
-        if ($authHeader) {
-            $headerContent = trim($authHeader->getFieldValue());
-
-            // we only support headers in the format: Authorization: xxx yyyyy
-            if (strpos($headerContent, ' ') === false) {
-                $identity = new Identity\GuestIdentity();
-                $mvcEvent->setParam('ZF\MvcAuth\Identity', $identity);
-                return $identity;
-            }
-
-            list($type, $credential) = preg_split('# #', $headerContent, 2);
-        }
-
-        if (! $type
-            && ! in_array($request->getMethod(), $this->requestsWithoutBodies)
-            && $request->getHeaders()->has('Content-Type')
-            && $request->getHeaders()->get('Content-Type')->match('application/x-www-form-urlencoded')
-            && $request->getPost('access_token')
+        $type = $this->getTypeFromMap($mvcEvent->getRouteMatch());
+        if (false === $type
+            && $this->httpAdapter instanceof HttpAuth
+            && $this->oauth2Server instanceof OAuth2Server
         ) {
-            $type = 'oauth2';
+            // Ambiguous situation; no matching type in map, but multiple
+            // authentication methods; do nothing.
+            $identity = new Identity\GuestIdentity();
+            $mvcEvent->setParam('ZF\MvcAuth\Identity', $identity);
+            return $identity;
         }
 
-        if (! $type && null !== $request->getQuery('access_token')) {
-            $type = 'oauth2';
-        }
-
-        if (! $type) {
+        $type = $type ?: $this->getTypeFromRequest($request);
+        if ($type === false) {
             if ($this->httpAdapter instanceof HttpAuth) {
+                $this->httpAdapter->setRequest($request);
+                $this->httpAdapter->setResponse($response);
                 $this->httpAdapter->challengeClient();
             }
             $identity = new Identity\GuestIdentity();
@@ -121,41 +121,44 @@ class DefaultAuthenticationListener
             return $identity;
         }
 
-        switch (strtolower($type)) {
+        switch ($type) {
             case 'basic':
             case 'digest':
 
-                if (!$this->httpAdapter instanceof HttpAuth) {
+                if (! $this->httpAdapter instanceof HttpAuth) {
                     $identity = new Identity\GuestIdentity();
                     $mvcEvent->setParam('ZF\MvcAuth\Identity', $identity);
                     return $identity;
                 }
 
+                $this->httpAdapter->setRequest($request);
+                $this->httpAdapter->setResponse($response);
+
                 $auth   = $mvcAuthEvent->getAuthenticationService();
                 $result = $auth->authenticate($this->httpAdapter);
                 $mvcAuthEvent->setAuthenticationResult($result);
 
-                if ($result->isValid()) {
-                    $resultIdentity = $result->getIdentity();
-
-                    // Pass full discovered identity to AuthenticatedIdentity object
-                    $identity = new Identity\AuthenticatedIdentity($resultIdentity);
-
-                    // But determine name separately
-                    $name = $resultIdentity;
-                    if (is_array($resultIdentity)) {
-                        $name = isset($resultIdentity['username'])
-                            ? $resultIdentity['username']
-                            : (string) $resultIdentity;
-                    }
-                    $identity->setName($name);
-
-                    // Set in MvcEvent
+                if (! $result->isValid()) {
+                    $identity = new Identity\GuestIdentity();
                     $mvcEvent->setParam('ZF\MvcAuth\Identity', $identity);
                     return $identity;
                 }
 
-                $identity = new Identity\GuestIdentity();
+                $resultIdentity = $result->getIdentity();
+
+                // Pass full discovered identity to AuthenticatedIdentity object
+                $identity = new Identity\AuthenticatedIdentity($resultIdentity);
+
+                // But determine name separately
+                $name = $resultIdentity;
+                if (is_array($resultIdentity)) {
+                    $name = isset($resultIdentity['username'])
+                        ? $resultIdentity['username']
+                        : (string) $resultIdentity;
+                }
+                $identity->setName($name);
+
+                // Set in MvcEvent
                 $mvcEvent->setParam('ZF\MvcAuth\Identity', $identity);
                 return $identity;
 
@@ -184,7 +187,97 @@ class DefaultAuthenticationListener
                 return $identity;
 
             case 'token':
-                throw new \Exception('zf-mvc-auth has not yet implemented a "token" authentication adapter');
+                throw new RuntimeException('zf-mvc-auth has not yet implemented a "token" authentication adapter');
+        }
+    }
+
+    /**
+     * Match the controller to an authentication type, based on the API to 
+     * which the controller belongs.
+     * 
+     * @param null|RouteMatch $routeMatch 
+     * @return string|false
+     */
+    private function getTypeFromMap(RouteMatch $routeMatch = null)
+    {
+        if (! $routeMatch) {
+            return false;
+        }
+
+        $controller = $routeMatch->getParam('controller', false);
+        if (false === $controller) {
+            return false;
+        }
+
+        foreach ($this->authMap as $api => $type) {
+            $api = rtrim($api, '\\') . '\\';
+            if (strlen($api > $controller)) {
+                continue;
+            }
+
+            if (0 === strpos($controller, $api)) {
+                return $type;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine the authentication type based on request information
+     * 
+     * @param HttpRequest $request 
+     * @return false|string
+     */
+    private function getTypeFromRequest(HttpRequest $request)
+    {
+        $type       = false;
+        $authHeader = $request->getHeader('Authorization');
+
+        if ($authHeader) {
+            $type = $this->getTypeFromAuthorizationHeader(trim($authHeader->getFieldValue()));
+        }
+
+        if (! $type
+            && ! in_array($request->getMethod(), $this->requestsWithoutBodies)
+            && $request->getHeaders()->has('Content-Type')
+            && $request->getHeaders()->get('Content-Type')->match('application/x-www-form-urlencoded')
+            && $request->getPost('access_token')
+        ) {
+            return 'oauth2';
+        }
+
+        if (! $type && null !== $request->getQuery('access_token')) {
+            return 'oauth2';
+        }
+
+        return $type;
+    }
+
+    /**
+     * Determine the authentication type from the authorization header contents
+     * 
+     * @param string $header 
+     * @return false|string
+     */
+    private function getTypeFromAuthorizationHeader($header)
+    {
+        // we only support headers in the format: Authorization: xxx yyyyy
+        if (strpos($header, ' ') === false) {
+            return false;
+        }
+
+        list($type, $credential) = preg_split('# #', $header, 2);
+
+        switch (strtolower($type)) {
+            case 'basic':
+                return 'basic';
+            case 'digest':
+                return 'digest';
+            case 'bearer':
+                return 'oauth2';
+            default:
+                return false;
         }
     }
 }

--- a/src/Authentication/HttpAdapter.php
+++ b/src/Authentication/HttpAdapter.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\MvcAuth\Authentication;
+
+use Zend\Authentication\Adapter\Http as HttpAuth;
+use Zend\Authentication\AuthenticationService;
+use Zend\Http\Request;
+use Zend\Http\Response;
+use ZF\MvcAuth\Identity;
+use ZF\MvcAuth\MvcAuthEvent;
+
+class HttpAdapter extends AbstractAdapter
+{
+    /**
+     * @var AuthenticationService
+     */
+    private $authenticationService;
+
+    /**
+     * @var HttpAuth
+     */
+    private $httpAuth;
+
+    /**
+     * @param HttpAuth $httpAuth
+     * @param AuthenticationService $authenticationService
+     */
+    public function __construct(HttpAuth $httpAuth, AuthenticationService $authenticationService)
+    {
+        $this->httpAuth = $httpAuth;
+        $this->authenticationService = $authenticationService;
+    }
+
+    /**
+     * @return array Array of types this adapter can handle.
+     */
+    public function provides()
+    {
+        $provides = array();
+
+        if ($this->httpAuth->getBasicResolver()) {
+            $provides[] = 'basic';
+        }
+
+        if ($this->httpAuth->getDigestResolver()) {
+            $provides[] = 'digest';
+        }
+
+        return $provides;
+    }
+
+    /**
+     * Perform pre-flight authentication operations.
+     *
+     * If invoked, issues a client challenge.
+     *
+     * @param Request $request
+     * @param Response $response
+     */
+    public function preAuth(Request $request, Response $response)
+    {
+        $this->httpAuth->setRequest($request);
+        $this->httpAuth->setResponse($response);
+        $this->httpAuth->challengeClient();
+    }
+
+    /**
+     * Attempt to authenticate the current request.
+     *
+     * @param Request $request
+     * @param Response $response
+     * @param MvcAuthEvent $mvcAuthEvent
+     * @return false|IdentityInterface False on failure, IdentityInterface
+     *     otherwise
+     */
+    public function authenticate(Request $request, Response $response, MvcAuthEvent $mvcAuthEvent)
+    {
+        $this->httpAuth->setRequest($request);
+        $this->httpAuth->setResponse($response);
+
+        $result = $this->authenticationService->authenticate($this->httpAuth);
+        $mvcAuthEvent->setAuthenticationResult($result);
+
+        if (! $result->isValid()) {
+            return false;
+        }
+
+        $resultIdentity = $result->getIdentity();
+
+        // Pass fully discovered identity to AuthenticatedIdentity instance
+        $identity = new Identity\AuthenticatedIdentity($resultIdentity);
+
+        // But determine the name separately
+        $name = $resultIdentity;
+        if (is_array($resultIdentity)) {
+            $name = isset($resultIdentity['username'])
+                ? $resultIdentity['username']
+                : (string) array_shift($resultIdentity);
+        }
+        $identity->setName($name);
+
+        return $identity;
+    }
+}

--- a/src/Authentication/HttpAdapter.php
+++ b/src/Authentication/HttpAdapter.php
@@ -7,7 +7,7 @@
 namespace ZF\MvcAuth\Authentication;
 
 use Zend\Authentication\Adapter\Http as HttpAuth;
-use Zend\Authentication\AuthenticationService;
+use Zend\Authentication\AuthenticationServiceInterface;
 use Zend\Http\Request;
 use Zend\Http\Response;
 use ZF\MvcAuth\Identity;
@@ -16,7 +16,7 @@ use ZF\MvcAuth\MvcAuthEvent;
 class HttpAdapter extends AbstractAdapter
 {
     /**
-     * @var AuthenticationService
+     * @var AuthenticationServiceInterface
      */
     private $authenticationService;
 
@@ -27,9 +27,9 @@ class HttpAdapter extends AbstractAdapter
 
     /**
      * @param HttpAuth $httpAuth
-     * @param AuthenticationService $authenticationService
+     * @param AuthenticationServiceInterface $authenticationService
      */
-    public function __construct(HttpAuth $httpAuth, AuthenticationService $authenticationService)
+    public function __construct(HttpAuth $httpAuth, AuthenticationServiceInterface $authenticationService)
     {
         $this->httpAuth = $httpAuth;
         $this->authenticationService = $authenticationService;

--- a/src/Authentication/OAuth2Adapter.php
+++ b/src/Authentication/OAuth2Adapter.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\MvcAuth\Authentication;
+
+use OAuth2\Request as OAuth2Request;
+use OAuth2\Server as OAuth2Server;
+use Zend\Http\Request;
+use Zend\Http\Response;
+use ZF\MvcAuth\Identity;
+use ZF\MvcAuth\MvcAuthEvent;
+
+class OAuth2Adapter extends AbstractAdapter
+{
+    /**
+     * @var OAuth2Server
+     */
+    private $oauth2Server;
+
+    /**
+     * Request methods that will not have request bodies
+     *
+     * @var array
+     */
+    private $requestsWithoutBodies = array(
+        'GET',
+        'HEAD',
+        'OPTIONS',
+    );
+
+    /**
+     * @param OAuth2Server $oauth2Server
+     */
+    public function __construct(OAuth2Server $oauth2Server)
+    {
+        $this->oauth2Server = $oauth2Server;
+    }
+
+    /**
+     * @return array Array of types this adapter can handle.
+     */
+    public function provides()
+    {
+        return array('oauth2', 'bearer');
+    }
+
+    /**
+     * Determine if the given request is a type (oauth2) that we recognize
+     *
+     * @param Request $request
+     * @return false|string
+     */
+    public function getTypeFromRequest(Request $request)
+    {
+        $type = parent::getTypeFromRequest($request);
+
+        if (false !== $type) {
+            return 'oauth2';
+        }
+
+        if (! in_array($request->getMethod(), $this->requestsWithoutBodies)
+            && $request->getHeaders()->has('Content-Type')
+            && $request->getHeaders()->get('Content-Type')->match('application/x-www-form-urlencoded')
+            && $request->getPost('access_token')
+        ) {
+            return 'oauth2';
+        }
+
+        if (null !== $request->getQuery('access_token')) {
+            return 'oauth2';
+        }
+
+        return false;
+    }
+
+    /**
+     * Perform pre-flight authentication operations.
+     *
+     * Performs a no-op; nothing needs to happen for this adapter.
+     *
+     * @param Request $request
+     * @param Response $response
+     */
+    public function preAuth(Request $request, Response $response)
+    {
+    }
+
+    /**
+     * Attempt to authenticate the current request.
+     *
+     * @param Request $request
+     * @param Response $response
+     * @param MvcAuthEvent $mvcAuthEvent
+     * @return false|IdentityInterface False on failure, IdentityInterface
+     *     otherwise
+     */
+    public function authenticate(Request $request, Response $response, MvcAuthEvent $mvcAuthEvent)
+    {
+        $content       = $request->getContent();
+        $oauth2request = new OAuth2Request($_GET, $_POST, array(), $_COOKIE, $_FILES, $_SERVER, $content);
+
+        if (! $this->oauth2Server->verifyResourceRequest($oauth2request)) {
+            return false;
+        }
+
+        $token    = $this->oauth2Server->getAccessTokenData($oauth2request);
+        $identity = new Identity\AuthenticatedIdentity($token);
+        $identity->setName($token['user_id']);
+        return $identity;
+    }
+}

--- a/src/Factory/DefaultAuthenticationListenerFactory.php
+++ b/src/Factory/DefaultAuthenticationListenerFactory.php
@@ -63,8 +63,8 @@ class DefaultAuthenticationListenerFactory implements FactoryInterface
         }
 
         // We must abort if no resolver was provided
-        if (!$httpAdapter->getBasicResolver()
-            && !$httpAdapter->getDigestResolver()
+        if (! $httpAdapter->getBasicResolver()
+            && ! $httpAdapter->getDigestResolver()
         ) {
             return false;
         }
@@ -82,14 +82,14 @@ class DefaultAuthenticationListenerFactory implements FactoryInterface
      */
     protected function createOAuth2Server(ServiceLocatorInterface $services)
     {
-        if (!$services->has('config')) {
+        if (! $services->has('config')) {
             return false;
         }
 
         $config = $services->get('config');
-        if (!isset($config['zf-oauth2']['storage'])
-            || !is_string($config['zf-oauth2']['storage'])
-            || !$services->has($config['zf-oauth2']['storage'])
+        if (! isset($config['zf-oauth2']['storage'])
+            || ! is_string($config['zf-oauth2']['storage'])
+            || ! $services->has($config['zf-oauth2']['storage'])
         ) {
             return false;
         }

--- a/src/Factory/DefaultAuthenticationListenerFactory.php
+++ b/src/Factory/DefaultAuthenticationListenerFactory.php
@@ -40,6 +40,11 @@ class DefaultAuthenticationListenerFactory implements FactoryInterface
             $listener->attach($oauth2Server);
         }
 
+        $authenticationTypes = $this->getAuthenticationTypes($services);
+        if ($authenticationTypes) {
+            $listener->addAuthenticationTypes($authenticationTypes);
+        }
+
         return $listener;
     }
 
@@ -101,5 +106,27 @@ class DefaultAuthenticationListenerFactory implements FactoryInterface
         $oauth2Server->addGrantType(new AuthorizationCode($storage));
 
         return new OAuth2Adapter($oauth2Server);
+    }
+
+    /**
+     * Retrieve custom authentication types
+     * 
+     * @param ServiceLocatorInterface $services 
+     * @return false|array
+     */
+    protected function getAuthenticationTypes(ServiceLocatorInterface $services)
+    {
+        if (! $services->has('config')) {
+            return false;
+        }
+
+        $config = $services->get('config');
+        if (! isset($config['zf-mvc-auth']['authentication']['types'])
+            || ! is_array($config['zf-mvc-auth']['authentication']['types'])
+        ) {
+            return false;
+        }
+
+        return $config['zf-mvc-auth']['authentication']['types'];
     }
 }

--- a/src/MvcRouteListener.php
+++ b/src/MvcRouteListener.php
@@ -56,8 +56,8 @@ class MvcRouteListener extends AbstractListenerAggregate
      */
     public function attach(EventManagerInterface $events)
     {
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'authentication'), 500);
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'authenticationPost'), 499);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'authentication'), -25);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'authenticationPost'), -26);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'authorization'), -600);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'authorizationPost'), -601);
     }

--- a/test/Authentication/DefaultAuthenticationListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationListenerTest.php
@@ -437,7 +437,7 @@ class DefaultAuthenticationListenerTest extends TestCase
     public function testAuthenticationUsesMapByToChooseAuthenticationMethod(
         $controller,
         $authType,
-        callable $requestProvider
+        $requestProvider
     ) {
         $this->setupMappedAuthenticatingListener($authType, $controller, $requestProvider());
         $identity = $this->listener->__invoke($this->mvcAuthEvent);
@@ -451,7 +451,7 @@ class DefaultAuthenticationListenerTest extends TestCase
     public function testGuestIdentityIsReturnedWhenNoAuthSchemesArePresent(
         $controller,
         $authType,
-        callable $requestProvider
+        $requestProvider
     ) {
         $map = array(
             'Foo\V2' => 'oauth2',
@@ -475,7 +475,7 @@ class DefaultAuthenticationListenerTest extends TestCase
     public function testUsesDefaultAuthenticationWhenNoAuthMapIsPresent(
         $controller,
         $authType,
-        callable $requestProvider
+        $requestProvider
     ) {
         switch ($authType) {
             case 'basic':
@@ -507,7 +507,7 @@ class DefaultAuthenticationListenerTest extends TestCase
     public function testDoesNotPerformAuthenticationWhenNoAuthMapPresentAndMultipleAuthSchemesAreDefined(
         $controller,
         $authType,
-        callable $requestProvider
+        $requestProvider
     ) {
         $this->setupHttpBasicAuth();
         // Minimal OAuth2 server mock, as we are not expecting any method calls

--- a/test/Authentication/DefaultAuthenticationListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationListenerTest.php
@@ -750,4 +750,29 @@ class DefaultAuthenticationListenerTest extends TestCase
         $identity = $this->listener->__invoke($this->mvcAuthEvent);
         $this->assertSame($expected, $identity);
     }
+
+    public function testListsProvidedNonAdapterAuthenticationTypes()
+    {
+        $types = array('foo');
+        $this->listener->addAuthenticationTypes($types);
+        $this->assertEquals($types, $this->listener->getAuthenticationTypes());
+    }
+
+    public function testListsCombinedAuthenticationTypes()
+    {
+        $types = array('foo');
+        $customTypes = array('bar');
+        $this->listener->addAuthenticationTypes($customTypes);
+
+        $adapter = $this->getMockBuilder('ZF\MvcAuth\Authentication\AdapterInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $adapter->expects($this->atLeastOnce())
+            ->method('provides')
+            ->will($this->returnValue($types));
+        $this->listener->attach($adapter);
+
+        // Order of merge matters, unfortunately
+        $this->assertEquals(array_merge($customTypes, $types), $this->listener->getAuthenticationTypes());
+    }
 }

--- a/test/Authentication/DefaultAuthenticationListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationListenerTest.php
@@ -14,6 +14,7 @@ use Zend\Authentication\Storage\NonPersistent;
 use Zend\Http\Request as HttpRequest;
 use Zend\Http\Response as HttpResponse;
 use Zend\Mvc\MvcEvent;
+use Zend\Mvc\Router\RouteMatch;
 use Zend\Stdlib\Request;
 use ZF\MvcAuth\Authentication\DefaultAuthenticationListener;
 use ZF\MvcAuth\MvcAuthEvent;
@@ -315,5 +316,273 @@ class DefaultAuthenticationListenerTest extends TestCase
         self::assertEquals($token['user_id'], $identity->getRoleId());
         self::assertEquals($token, $identity->getAuthenticationIdentity());
 
+    }
+
+    public function setupHttpBasicAuth()
+    {
+        $httpAuth = new HttpAuth(array(
+            'accept_schemes' => 'basic',
+            'realm' => 'My Web Site',
+            'digest_domains' => '/',
+            'nonce_timeout' => 3600,
+        ));
+        $httpAuth->setBasicResolver(new HttpAuth\ApacheResolver(__DIR__ . '/../TestAsset/htpasswd'));
+        $this->listener->setHttpAdapter($httpAuth);
+    }
+
+    public function setupHttpDigestAuth()
+    {
+        $httpAuth = $this->getMockBuilder('Zend\Authentication\Adapter\Http')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $resultIdentity = new AuthenticationResult(AuthenticationResult::SUCCESS, array(
+            'username' => 'user',
+            'realm' => 'User Area',
+        ));
+        $httpAuth->expects($this->once())
+            ->method('authenticate')
+            ->will($this->returnValue($resultIdentity));
+
+        $this->listener->setHttpAdapter($httpAuth);
+    }
+
+    public function mappedAuthenticationControllers()
+    {
+        return array(
+            'Foo\V2' => array(
+                'Foo\V2\Rest\Status\StatusController',
+                'oauth2',
+                function () {
+                    $request = new HttpRequest();
+                    $request->getHeaders()->addHeaderLine('Authorization: Bearer TOKEN');
+                    return $request;
+                },
+            ),
+            'Bar\V1' => array(
+                'Bar\V1\Rpc\Ping\PingController',
+                'basic',
+                function () {
+                    $request = new HttpRequest();
+                    $request->getHeaders()->addHeaderLine('Authorization: Basic dXNlcjp1c2Vy');
+                    return $request;
+                },
+            ),
+            'Baz\V3' => array(
+                'Baz\V3\Rest\User\UserController',
+                'digest',
+                function () {
+                    $request = new HttpRequest();
+                    $request->getHeaders()->addHeaderLine(
+                        'Authorization: Digest username="user", '
+                        . 'realm="User Area", '
+                        . 'nonce="AB10BC99", '
+                        . 'uri="/", '
+                        . 'qop="auth", '
+                        . 'nc="AB10BC99", '
+                        . 'cnonce="AB10BC99", '
+                        . 'response="b19adb0300f4bd21baef59b0b4814898", '
+                        . 'opaque=""'
+                    );
+                    return $request;
+                },
+            ),
+        );
+    }
+
+    public function setupMappedAuthenticatingListener($authType, $controller, $request)
+    {
+        switch ($authType) {
+            case 'basic':
+                $this->setupHttpBasicAuth();
+                break;
+            case 'digest':
+                $this->setupHttpDigestAuth();
+                break;
+            case 'oauth2':
+                $this->setupMockOAuth2Server(array(
+                    'user_id' => 'test',
+                ));
+                break;
+        }
+
+        $map = array(
+            'Foo\V2' => 'oauth2',
+            'Bar\V1' => 'basic',
+            'Baz\V3' => 'digest',
+        );
+        $this->listener->setAuthMap($map);
+        $routeMatch = new RouteMatch(array('controller' => $controller));
+        $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
+        $mvcEvent
+            ->setRequest($request)
+            ->setRouteMatch($routeMatch);
+    }
+
+    /**
+     * @dataProvider mappedAuthenticationControllers
+     * @group 55
+     */
+    public function testAuthenticationUsesMapByToChooseAuthenticationMethod(
+        $controller,
+        $authType,
+        callable $requestProvider
+    ) {
+        $this->setupMappedAuthenticatingListener($authType, $controller, $requestProvider());
+        $identity = $this->listener->__invoke($this->mvcAuthEvent);
+        $this->assertInstanceOf('ZF\MvcAuth\Identity\AuthenticatedIdentity', $identity);
+    }
+
+    /**
+     * @dataProvider mappedAuthenticationControllers
+     * @group 55
+     */
+    public function testGuestIdentityIsReturnedWhenNoAuthSchemesArePresent(
+        $controller,
+        $authType,
+        callable $requestProvider
+    ) {
+        $map = array(
+            'Foo\V2' => 'oauth2',
+            'Bar\V1' => 'basic',
+            'Baz\V3' => 'digest',
+        );
+        $this->listener->setAuthMap($map);
+        $routeMatch = new RouteMatch(array('controller' => $controller));
+        $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
+        $mvcEvent
+            ->setRequest($requestProvider())
+            ->setRouteMatch($routeMatch);
+        $identity = $this->listener->__invoke($this->mvcAuthEvent);
+        $this->assertInstanceOf('ZF\MvcAuth\Identity\GuestIdentity', $identity);
+    }
+
+    /**
+     * @dataProvider mappedAuthenticationControllers
+     * @group 55
+     */
+    public function testUsesDefaultAuthenticationWhenNoAuthMapIsPresent(
+        $controller,
+        $authType,
+        callable $requestProvider
+    ) {
+        switch ($authType) {
+            case 'basic':
+                $this->setupHttpBasicAuth();
+                break;
+            case 'digest':
+                $this->setupHttpDigestAuth();
+                break;
+            case 'oauth2':
+                $this->setupMockOAuth2Server(array(
+                    'user_id' => 'test',
+                ));
+                break;
+        }
+
+        $routeMatch = new RouteMatch(array('controller' => $controller));
+        $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
+        $mvcEvent
+            ->setRequest($requestProvider())
+            ->setRouteMatch($routeMatch);
+        $identity = $this->listener->__invoke($this->mvcAuthEvent);
+        $this->assertInstanceOf('ZF\MvcAuth\Identity\AuthenticatedIdentity', $identity);
+    }
+
+    /**
+     * @dataProvider mappedAuthenticationControllers
+     * @group 55
+     */
+    public function testDoesNotPerformAuthenticationWhenNoAuthMapPresentAndMultipleAuthSchemesAreDefined(
+        $controller,
+        $authType,
+        callable $requestProvider
+    ) {
+        $this->setupHttpBasicAuth();
+        // Minimal OAuth2 server mock, as we are not expecting any method calls
+        $server = $this->getMockBuilder('OAuth2\Server')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->listener->setOauth2Server($server);
+
+        $routeMatch = new RouteMatch(array('controller' => $controller));
+        $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
+        $mvcEvent
+            ->setRequest($requestProvider())
+            ->setRouteMatch($routeMatch);
+
+        $identity = $this->listener->__invoke($this->mvcAuthEvent);
+        $this->assertInstanceOf('ZF\MvcAuth\Identity\GuestIdentity', $identity);
+    }
+
+    /**
+     * @group 55
+     */
+    public function testDoesNotPerformAuthenticationWhenMatchedControllerHasNoAuthMapEntryAndAuthSchemesAreDefined()
+    {
+        // Minimal HTTP adapter mock, as we are not expecting any method calls
+        $httpAuth = $this->getMockBuilder('Zend\Authentication\Adapter\Http')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->listener->setHttpAdapter($httpAuth);
+
+        // Minimal OAuth2 server mock, as we are not expecting any method calls
+        $server = $this->getMockBuilder('OAuth2\Server')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->listener->setOauth2Server($server);
+
+        $map = array(
+            'Foo\V2' => 'oauth2',
+            'Bar\V1' => 'basic',
+            'Baz\V3' => 'digest',
+        );
+        $this->listener->setAuthMap($map);
+
+        $request = new HttpRequest();
+        $request->getHeaders()->addHeaderLine('Authorization: Bearer TOKEN');
+
+        $routeMatch = new RouteMatch(array('controller' => 'FooBarBaz\V4\Rest\Test\TestController'));
+
+        $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
+        $mvcEvent
+            ->setRequest($request)
+            ->setRouteMatch($routeMatch);
+
+        $identity = $this->listener->__invoke($this->mvcAuthEvent);
+        $this->assertInstanceOf('ZF\MvcAuth\Identity\GuestIdentity', $identity);
+    }
+
+    /**
+     * @group 55
+     */
+    public function testDoesNotPerformAuthenticationWhenMatchedControllerHasAuthMapEntryNotInDefinedAuthSchemes()
+    {
+        // Minimal HTTP adapter mock, as we are not expecting any method calls
+        $httpAuth = $this->getMockBuilder('Zend\Authentication\Adapter\Http')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->listener->setHttpAdapter($httpAuth);
+
+        // No OAuth2 server, intentionally
+
+        $map = array(
+            'Foo\V2' => 'oauth2',
+            'Bar\V1' => 'basic',
+            'Baz\V3' => 'digest',
+        );
+        $this->listener->setAuthMap($map);
+
+        $request = new HttpRequest();
+        $request->getHeaders()->addHeaderLine('Authorization: Bearer TOKEN');
+
+        $routeMatch = new RouteMatch(array('controller' => 'Foo\V2\Rest\Test\TestController'));
+
+        $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
+        $mvcEvent
+            ->setRequest($request)
+            ->setRouteMatch($routeMatch);
+
+        $identity = $this->listener->__invoke($this->mvcAuthEvent);
+        $this->assertInstanceOf('ZF\MvcAuth\Identity\GuestIdentity', $identity);
     }
 }

--- a/test/Factory/DefaultAuthenticationListenerFactoryTest.php
+++ b/test/Factory/DefaultAuthenticationListenerFactoryTest.php
@@ -172,4 +172,29 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $this->assertInstanceOf('ZF\MvcAuth\Authentication\DefaultAuthenticationListener', $listener);
         $this->assertContains('digest', $listener->getAuthenticationTypes());
     }
+
+    public function testCallingFactoryWithCustomAuthenticatinTypesReturnsListenerComposingThem()
+    {
+        $authenticationService = $this->getMock('Zend\Authentication\AuthenticationServiceInterface');
+        $this->services->setService('authentication', $authenticationService);
+        $this->services->setService('config', array(
+            'zf-mvc-auth' => array(
+                'authentication' => array(
+                    'http' => array(
+                        'accept_schemes' => array('digest'),
+                        'realm' => 'User Area',
+                        'digest_domains' => '/',
+                        'nonce_timeout' => 3600,
+                        'htdigest' => __DIR__ . '/../TestAsset/htdigest'
+                    ),
+                    'types' => array(
+                        'token',
+                    ),
+                ),
+            ),
+        ));
+        $listener = $this->factory->createService($this->services);
+        $this->assertInstanceOf('ZF\MvcAuth\Authentication\DefaultAuthenticationListener', $listener);
+        $this->assertEquals(array('digest', 'token'), $listener->getAuthenticationTypes());
+    }
 }

--- a/test/Factory/DefaultAuthenticationListenerFactoryTest.php
+++ b/test/Factory/DefaultAuthenticationListenerFactoryTest.php
@@ -131,6 +131,8 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
 
     public function testCallingFactoryWithBasicSchemeAndHtpasswdValueReturnsListenerWithHttpAdapter()
     {
+        $authenticationService = $this->getMock('Zend\Authentication\AuthenticationServiceInterface');
+        $this->services->setService('authentication', $authenticationService);
         $this->services->setService('config', array(
             'zf-mvc-auth' => array(
                 'authentication' => array(
@@ -146,11 +148,13 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         ));
         $listener = $this->factory->createService($this->services);
         $this->assertInstanceOf('ZF\MvcAuth\Authentication\DefaultAuthenticationListener', $listener);
-        $this->assertAttributeInstanceOf('Zend\Authentication\Adapter\Http', 'httpAdapter', $listener);
+        $this->assertContains('basic', $listener->getAuthenticationTypes());
     }
 
     public function testCallingFactoryWithDigestSchemeAndHtdigestValueReturnsListenerWithHttpAdapter()
     {
+        $authenticationService = $this->getMock('Zend\Authentication\AuthenticationServiceInterface');
+        $this->services->setService('authentication', $authenticationService);
         $this->services->setService('config', array(
             'zf-mvc-auth' => array(
                 'authentication' => array(
@@ -166,6 +170,6 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         ));
         $listener = $this->factory->createService($this->services);
         $this->assertInstanceOf('ZF\MvcAuth\Authentication\DefaultAuthenticationListener', $listener);
-        $this->assertAttributeInstanceOf('Zend\Authentication\Adapter\Http', 'httpAdapter', $listener);
+        $this->assertContains('digest', $listener->getAuthenticationTypes());
     }
 }

--- a/test/MvcRouteListenerTest.php
+++ b/test/MvcRouteListenerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace ZFTest\MvcAuth;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\EventManager\EventManager;
+use ZF\MvcAuth\MvcRouteListener;
+
+class MvcRouteListenerTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->events = new EventManager;
+        $this->auth   = $this
+            ->getMockBuilder('Zend\Authentication\AuthenticationService')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->event  = $this
+            ->getMockBuilder('ZF\MvcAuth\MvcAuthEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->listener = new MvcRouteListener(
+            $this->event,
+            $this->events,
+            $this->auth
+        );
+    }
+
+    public function assertListenerAtPriority($priority, $expectedCallback, $listeners, $message = '')
+    {
+        $found = false;
+        foreach ($listeners as $listener) {
+            $this->assertInstanceOf('Zend\Stdlib\CallbackHandler', $listener);
+            if ($listener->getMetadatum('priority') !== $priority) {
+                continue;
+            }
+
+            if ($listener->getCallback() === $expectedCallback) {
+                $found = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($found, $message);
+    }
+
+    public function testRegistersAuthenticationListenerOnExpectedPriority()
+    {
+        $this->events->attach($this->listener);
+        $this->assertListenerAtPriority(
+            -25,
+            array($this->listener, 'authentication'),
+            $this->events->getListeners('route')
+        );
+    }
+
+    public function testRegistersPostAuthenticationListenerOnExpectedPriority()
+    {
+        $this->events->attach($this->listener);
+        $this->assertListenerAtPriority(
+            -26,
+            array($this->listener, 'authenticationPost'),
+            $this->events->getListeners('route')
+        );
+    }
+
+    public function testRegistersAuthorizationListenerOnExpectedPriority()
+    {
+        $this->events->attach($this->listener);
+        $this->assertListenerAtPriority(
+            -600,
+            array($this->listener, 'authorization'),
+            $this->events->getListeners('route')
+        );
+    }
+
+    public function testRegistersPostAuthorizationListenerOnExpectedPriority()
+    {
+        $this->events->attach($this->listener);
+        $this->assertListenerAtPriority(
+            -601,
+            array($this->listener, 'authorizationPost'),
+            $this->events->getListeners('route')
+        );
+    }
+}


### PR DESCRIPTION
This patch provides the mechanics necessary to implement per-API authentication.

First, I've changed the priority at which each of the authentication and authentication.post events occur. Prior to these changes, they happened at 500 and 499, respectively; they now happen at -25 and -26 (i.e., after routing, but prior to other Apigility-related listeners).

Second, you can now create a "map" key in the "authentication" configuration. The value of this should be a set of API/module + version / authentication type pairs. As an example:

```php
return [
    'authentication' => [
        'map' => [
            'Status\V2' => 'oauth2',
            'Ping\V1' => 'basic',
            'Images\V3' => 'digest',
        ],
    ],
];
```

In the above, v2 of the "Status" module/API would use the configured OAuth2 authentication, v1 of the "Ping" module/API would use the configured HTTP Basic authentication, and v3 of the "Images" module/API woulduse the configured HTTP Digest authentication.

In order to retain backwards compatibility, the following rules apply:

- **if**
 - no authentication schemes are defined
 - **then** do not perform authentication
- **if**
 - a single authentication scheme is defined
 - **and** no map is present
 - **then** use the defined authentication
- **if**
 - multiple authentication schemes are defined
 - **and** no map is present
 - **then** do not perform authentication
- **if**
 - one or more authentication schemes are defined
 - **and** a map is present
 - **and** the current API/module does not have an entry in the map
 - **then** do not perform authentication
- **if**
 - one or more authentication schemes are defined
 - **and** a map is present
 - **and** the current API/module has an entry in the map
 - **and** the entry does not match one of the authentication schemes
 - **then** do not perform authentication
- **if**
 - one or more authentication schemes are defined
 - **and** a map is present
 - **and** the current API/module has an entry in the map
 - **and** that entry matches one of the authentication schemes
 - **then** use the defined authentication

All existing tests continue to pass, and tests were added for each of the above scenarios.

## Allowing user-configured authentication types

One place this falls down is if a user has a custom authentication type, as currently that means they will not be able to specify their custom authentication type for an API/module. While we likely will not want to allow configuring custom adapters via the UI, having the UI aware of the type _does_ make sense, as it allows mapping APIs to those types.

The best way to make this happen is to refactor the `DefaultAuthenticationListener` to be aware of _authentication adapters_. This approach would do the following:

- Separate the implementation specific details into their own adapters, slimming down the code in the listener.
- Provide a clean, simple, and documented API for providing additional authentication adapters _other_ _than_ writing an event listener.
- Provide a mechanism for exposing authentication types for purposes of mapping authentication to APIs.

The proposed authentication adapter interface is:

```php
namespace ZF\MvcAuth\Authentication;

use Zend\Http\Request;
use Zend\Http\Response;
use ZF\MvcAuth\Identity\IdentityInterface;

interface AdapterInterface
{
    /**
     * @return array Array of types this adapter can handle
     */
    public function provides();

    /**
     * Attempt to retrieve the authentication type based on the request.
     *
     * Allows an adapter to have custom logic for detecting if a request
     * might be providing credentials it's interested in.
     *
     * @param Request $request
     * @return false|string
     */
    public function getTypeFromRequest(Request $request);

    /**
     * Perform pre-flight authentication operations.
     *
     * Use case would be for providing authentication challenge headers.
     *
     * @param Request $request
     * @param Response $response
     * @return void|Response
     */
    public function preAuth(Request $request, Response $response);

    /**
     * Attempt to authenticate the current request.
     *
     * @param Request $request
     * @param Response $response
     * @return false|IdentityInterface False on failure, IdentityInterface
     *     otherwise
     */
    public function authenticate(Request $request, Response $response);
}
```

The current logic specific to HTTP and OAuth2 authentication would be moved into discrete adapter implementations, and the `DefaultAuthenticationListenerFactory` would be updated to selectively create these adapters and attach them to the listener.

For those wanting to use custom `authentication` event listeners, we will provide a configuration key for specifying type names that these listeners support; however, the logic will be such that if no adapter can satisfy the type, a `GuestIdentity` will be returned; it will be up to the custom listener to perform the appropriate checks to see if it should be used, and to return an identity following the authentication check.

The `DefaultAuthenticationListener` will be updated to add the following methods:

```php
/**
 * @return array
 */
public function attach(AdapterInterface $adapter);

/**
 * @return array Array of all supported authentication types, including both
 *     those provided by adapters and those provided via configuration.
 */
public function getAuthenticationTypes();
```

## Tasklist

- [X] Implement authentication maps (API/Module -> authentication type)
- [x] Implement custom authentication awareness
  - [x] Create authentication adapter interface
  - [x] Modify DefaultAuthenticationListener logic to delegate to adapters
    - [x] `getTypeFromRequest()` to delegate to adapters for type, if none in authorization header
    - [x] Call `preAuth()` on all adapters if no type found
    - [x] Retrieve adapter by type and use it to authenticate
- [x] Create functionality for determining configured types
  - [x] Pull from configured adapters (delegator factories can be used to add more adapters, so pulling the service will allow querying adapters)
  - [x] Pull from a special configuration key
