### PR TITLE
Allow creating multiple HTTP and/or OAuth2 adapters w/separate configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,11 +479,83 @@ identity will be used for the duration of the request.
 Adapters are attached to the `DefaultAuthenticationListener`. To attach your
 custom adapter, you will need to do one of the following:
 
+- Define named HTTP and/or OAuth2 adapters via configuration.
 - During an event listener, pull your adapter and the
   `DefaultAuthenticationListener` services, and attach your adapter to the
   latter.
 - Create a `DelegatorFactory` for the `DefaultAuthenticationListener` that
   attaches your custom adapter before returning the listener.
+
+#### Defining named HTTP and/or OAuth2 adapters
+
+Since HTTP and OAuth2 support is built-in, `zf-mvc-auth` provides a
+configuration-driven approach for creating named adapters of these types. Each
+requires a unique key under the `zf-mvc-auth.authentication.adapters`
+configuration, and each type has its own format.
+
+```php
+return array(
+    /* ... */
+    'zf-mvc-auth' => array(
+        'authentication' => array(
+            'adapters' => array(
+                'api' => array(
+                    // This defines an HTTP adapter that can satisfy both
+                    // basic and digest.
+                    'adapter' => 'ZF\MvcAuth\Authentication\HttpAdapter',
+                    'options' => array(
+                        'accept_schemes' => array('basic', 'digest'),
+                        'realm' => 'api',
+                        'digest_domains' => 'https://example.com',
+                        'nonce_timeout' => 3600,
+                        'htpasswd' => 'data/htpasswd',
+                        'htdigest' => 'data/htdigest',
+                    ),
+                ),
+                'user' => array(
+                    // This defines an OAuth2 adapter backed by PDO.
+                    'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
+                    'storage' => array(
+                        'adapter' => 'pdo',
+                        'dsn' => 'mysql:host=localhost;dbname=oauth2',
+                        'username' => 'username',
+                        'password' => 'password',
+                        'options' => aray(
+                            1002 => 'SET NAMES utf8', // PDO::MYSQL_ATTR_INIT_COMMAND
+                        ),
+                    ),
+                ),
+                'client' => array(
+                    // This defines an OAuth2 adapter backed by Mongo.
+                    'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
+                    'storage' => array(
+                        'adapter' => 'mongo',
+                        'locator_name' => 'SomeServiceName', // If provided, pulls the given service
+                        'dsn' => 'mongodb://localhost',
+                        'database' => 'oauth2',
+                        'options' => array(
+                            'username' => 'username',
+                            'password' => 'password',
+                            'connectTimeoutMS' => 500,
+                        ),
+                    ),
+                ),
+            ),
+            /* ... */
+        ),
+        /* ... */
+    ),
+    /* ... */
+);
+```
+
+The above configuration would provide the authentication types
+`array('api-basic', 'api-digest', 'user', 'client')` to your application, which
+can each them be associated in the authentication type map.
+
+If you use `zf-apigility-admin`'s Admin API and/or the Apigility UI to
+configure authentication adapters, the above configuration will be created for
+you.
 
 #### Attaching an adapter during an event listener
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,71 @@ return array(
 
 This key and its contents **must** be created manually.
 
+##### Sub-key: `adapters`
+
+- Since 1.1.0.
+
+Starting in 1.1.0, with the introduction of adapters, you can also configure
+named HTTP and OAuth2 adapters. The name provided will be used as the
+authentication type for purposes of mapping APIs to an authentication adapter.
+
+The format for the `adapters` key is a key/value pair, with the key acting as
+the type, and the value as configuration for providing a
+`ZF\MvcAuth\Authentication\HttpAdapter` or
+`ZF\MvcAuth\Authentication\OAuth2Adapter` instance, as follows:
+
+```php
+return array(
+    'zf-mvc-auth' => array(
+        'authentication' => array(
+            'adapters' => array(
+                'api' => array(
+                    // This defines an HTTP adapter that can satisfy both
+                    // basic and digest.
+                    'adapter' => 'ZF\MvcAuth\Authentication\HttpAdapter',
+                    'options' => array(
+                        'accept_schemes' => array('basic', 'digest'),
+                        'realm' => 'api',
+                        'digest_domains' => 'https://example.com',
+                        'nonce_timeout' => 3600,
+                        'htpasswd' => 'data/htpasswd',
+                        'htdigest' => 'data/htdigest',
+                    ),
+                ),
+                'user' => array(
+                    // This defines an OAuth2 adapter backed by PDO.
+                    'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
+                    'storage' => array(
+                        'adapter' => 'pdo',
+                        'dsn' => 'mysql:host=localhost;dbname=oauth2',
+                        'username' => 'username',
+                        'password' => 'password',
+                        'options' => aray(
+                            1002 => 'SET NAMES utf8', // PDO::MYSQL_ATTR_INIT_COMMAND
+                        ),
+                    ),
+                ),
+                'client' => array(
+                    // This defines an OAuth2 adapter backed by Mongo.
+                    'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
+                    'storage' => array(
+                        'adapter' => 'mongo',
+                        'locator_name' => 'SomeServiceName', // If provided, pulls the given service
+                        'dsn' => 'mongodb://localhost',
+                        'database' => 'oauth2',
+                        'options' => array(
+                            'username' => 'username',
+                            'password' => 'password',
+                            'connectTimeoutMS' => 500,
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),
+);
+```
+
 #### Key: `authorization`
 
 #### Sub-Key: `deny_by_default`

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -16,6 +16,11 @@ return array(
             'authorization' => 'ZF\MvcAuth\Authorization\AuthorizationInterface',
             'ZF\MvcAuth\Authorization\AuthorizationInterface' => 'ZF\MvcAuth\Authorization\AclAuthorization',
         ),
+        'delegator_factories' => array(
+            'ZF\MvcAuth\Authentication\DefaultAuthenticationListener' => array(
+                'ZF\MvcAuth\Factory\AuthenticationAdapterDelegatorFactory',
+            ),
+        ),
         'factories' => array(
             'ZF\MvcAuth\Authentication' => 'ZF\MvcAuth\Factory\AuthenticationServiceFactory',
             'ZF\MvcAuth\ApacheResolver' => 'ZF\MvcAuth\Factory\ApacheResolverFactory',
@@ -38,6 +43,8 @@ return array(
              * - http
              * - oauth2
              *
+             * Note: as of 1.1, these are deprecated.
+             *
             'http' => array(
                 'accept_schemes' => array('basic', 'digest'),
                 'realm' => 'My Web Site',
@@ -45,6 +52,49 @@ return array(
                 'nonce_timeout' => 3600,
                 'htpasswd' => APPLICATION_PATH . '/data/htpasswd' // htpasswd tool generated
                 'htdigest' => APPLICATION_PATH . '/data/htdigest' // @see http://www.askapache.com/online-tools/htpasswd-generator/
+            ),
+             *
+             * Starting in 1.1, we have an "adapters" key, which is a key/value
+             * pair of adapter name -> adapter configuration information. This
+             * looks like the following for the HTTP basic/digest and OAuth2
+             * adapters:
+            'adapters' => array
+                'api' => array(
+                    'adapter' => 'ZF\MvcAuth\Authentication\HttpAdapter',
+                    'options' => array(
+                        'accept_schemes' => array('basic', 'digest'),
+                        'realm' => 'api',
+                        'digest_domains' => 'https://example.com',
+                        'nonce_timeout' => 3600,
+                        'htpasswd' => 'data/htpasswd',
+                        'htdigest' => 'data/htdigest',
+                    ),
+                ),
+                'user' => array(
+                    'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
+                    'storage' => array(
+                        'adapter' => 'pdo',
+                        'dsn' => 'mysql:host=localhost;dbname=oauth2',
+                        'username' => 'username',
+                        'password' => 'password',
+                        'options' => aray(
+                            1002 => 'SET NAMES utf8', // PDO::MYSQL_ATTR_INIT_COMMAND
+                        ),
+                    ),
+                ),
+                'client' => array(
+                    'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
+                    'storage' => array(
+                        'adapter' => 'mongo',
+                        'dsn' => 'mongodb://localhost',
+                        'database' => 'oauth2',
+                        'options' => array(
+                            'username' => 'username',
+                            'password' => 'password',
+                            'connectTimeoutMS' => 500,
+                        ),
+                    ),
+                ),
             ),
              *
              * Next, we also have a "map", which maps an API module (with

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -86,6 +86,7 @@ return array(
                     'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
                     'storage' => array(
                         'adapter' => 'mongo',
+                        'locator_name' => 'SomeServiceName', // If provided, pulls the given service
                         'dsn' => 'mongodb://localhost',
                         'database' => 'oauth2',
                         'options' => array(

--- a/src/Authentication/AbstractAdapter.php
+++ b/src/Authentication/AbstractAdapter.php
@@ -11,6 +11,13 @@ use Zend\Http\Request;
 abstract class AbstractAdapter implements AdapterInterface
 {
     /**
+     * Authorization token types this adapter can fulfill.
+     * 
+     * @var array
+     */
+    protected $authorizationTokenTypes = array();
+
+    /**
      * Determine if the incoming request provides either basic or digest
      * credentials
      *
@@ -28,7 +35,7 @@ abstract class AbstractAdapter implements AdapterInterface
         $authorization = trim($authorization->getFieldValue());
         $type = $this->getTypeFromAuthorizationHeader($authorization);
 
-        if (! in_array($type, $this->provides())) {
+        if (! in_array($type, $this->authorizationTokenTypes)) {
             return false;
         }
 

--- a/src/Authentication/HttpAdapter.php
+++ b/src/Authentication/HttpAdapter.php
@@ -21,33 +21,63 @@ class HttpAdapter extends AbstractAdapter
     private $authenticationService;
 
     /**
+     * Authorization header token types this adapter can fulfill.
+     * 
+     * @var array
+     */
+    protected $authorizationTokenTypes = array('basic', 'digest');
+
+    /**
      * @var HttpAuth
      */
     private $httpAuth;
 
     /**
+     * Base to use when prefixing "provides" strings
+     * 
+     * @var null|string
+     */
+    private $providesBase;
+
+    /**
      * @param HttpAuth $httpAuth
      * @param AuthenticationServiceInterface $authenticationService
+     * @param null|string $providesBase
      */
-    public function __construct(HttpAuth $httpAuth, AuthenticationServiceInterface $authenticationService)
-    {
+    public function __construct(
+        HttpAuth $httpAuth,
+        AuthenticationServiceInterface $authenticationService,
+        $providesBase = null
+    ) {
         $this->httpAuth = $httpAuth;
         $this->authenticationService = $authenticationService;
+
+        if (is_string($providesBase) && ! empty($providesBase)) {
+            $this->providesBase = $providesBase;
+        }
     }
 
     /**
+     * Returns the "types" this adapter can handle.
+     *
+     * If no $providesBase is present, returns "basic" and/or "digest" in the
+     * array, based on what resolvers are present in the adapter; if
+     * $providesBase is present, the same strings are returned, only with the
+     * $providesBase prefixed, along with a "-" separator.
+     *
      * @return array Array of types this adapter can handle.
      */
     public function provides()
     {
-        $provides = array();
+        $providesBase = $this->providesBase ? $this->providesBase . '-' : '';
+        $provides     = array();
 
         if ($this->httpAuth->getBasicResolver()) {
-            $provides[] = 'basic';
+            $provides[] = $providesBase . 'basic';
         }
 
         if ($this->httpAuth->getDigestResolver()) {
-            $provides[] = 'digest';
+            $provides[] = $providesBase . 'digest';
         }
 
         return $provides;

--- a/src/Authentication/OAuth2Adapter.php
+++ b/src/Authentication/OAuth2Adapter.php
@@ -16,9 +16,23 @@ use ZF\MvcAuth\MvcAuthEvent;
 class OAuth2Adapter extends AbstractAdapter
 {
     /**
+     * Authorization header token types this adapter can fulfill.
+     * 
+     * @var array
+     */
+    protected $authorizationTokenTypes = array('bearer');
+
+    /**
      * @var OAuth2Server
      */
     private $oauth2Server;
+
+    /**
+     * Authentication types this adapter provides.
+     * 
+     * @var array
+     */
+    private $providesTypes = array('oauth2');
 
     /**
      * Request methods that will not have request bodies
@@ -34,9 +48,17 @@ class OAuth2Adapter extends AbstractAdapter
     /**
      * @param OAuth2Server $oauth2Server
      */
-    public function __construct(OAuth2Server $oauth2Server)
+    public function __construct(OAuth2Server $oauth2Server, $types = null)
     {
         $this->oauth2Server = $oauth2Server;
+
+        if (is_string($types) && ! empty($types)) {
+            $types = array($types);
+        }
+
+        if (is_array($types)) {
+            $this->providesTypes = $types;
+        }
     }
 
     /**
@@ -44,7 +66,7 @@ class OAuth2Adapter extends AbstractAdapter
      */
     public function provides()
     {
-        return array('oauth2', 'bearer');
+        return $this->providesTypes;
     }
 
     /**

--- a/src/Factory/AuthenticationAdapterDelegatorFactory.php
+++ b/src/Factory/AuthenticationAdapterDelegatorFactory.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+namespace ZF\MvcAuth\Factory;
+
+use Zend\ServiceManager\DelegatorFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class AuthenticationAdapterDelegatorFactory implements DelegatorFactoryInterface
+{
+    public function createDelegatorWithName(
+        ServiceLocatorInterface $services,
+        $name,
+        $requestedName,
+        $callback
+    ) {
+        $listener = $callback();
+
+        $config = $services->get('Config');
+        if (! isset($config['zf-mvc-auth']['authentication']['adapters'])
+            || ! is_array($config['zf-mvc-auth']['authentication']['adapters'])
+        ) {
+            return $listener;
+        }
+
+        foreach ($config['zf-mvc-auth']['authentication']['adapters'] as $type => $data) {
+            if (! isset($data['adapter']) || ! is_string($data['adapter'])) {
+                continue;
+            }
+
+            switch ($data['adapter']) {
+                case 'ZF\MvcAuth\Authentication\HttpAdapter':
+                    $adapter = AuthenticationHttpAdapterFactory::factory($type, $data, $services);
+                    break;
+                case 'ZF\MvcAuth\Authentication\OAuth2Adapter':
+                    $adapter = AuthenticationOAuth2AdapterFactory::factory($type, $data, $services);
+                    break;
+                default:
+                    $adapter = false;
+                    break;
+            }
+
+            if ($adapter) {
+                $listener->attach($adapter);
+            }
+        }
+
+        return $listener;
+    }
+}

--- a/src/Factory/AuthenticationHttpAdapterFactory.php
+++ b/src/Factory/AuthenticationHttpAdapterFactory.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+namespace ZF\MvcAuth\Factory;
+
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\MvcAuth\Authentication\HttpAdapter;
+
+final class AuthenticationHttpAdapterFactory
+{
+    /**
+     * Intentionally empty and private to prevent instantiation
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Create an instance of ZF\MvcAuth\Authentication\HttpAdapter based on
+     * the configuration provided and the registered AuthenticationService.
+     * 
+     * @param string $type The base "type" the adapter will provide
+     * @param array $config 
+     * @param ServiceLocatorInterface $services 
+     * @return HttpAdapter
+     */
+    public static function factory($type, array $config, ServiceLocatorInterface $services)
+    {
+        if (! $services->has('authentication')) {
+            throw new ServiceNotCreatedException(
+                'Cannot create HTTP authentication adapter; missing AuthenticationService'
+            );
+        }
+
+        if (! isset($config['options']) && ! is_array($config['options'])) {
+            throw new ServiceNotCreatedException(
+                'Cannot create HTTP authentication adapter; missing options'
+            );
+        }
+
+        return new HttpAdapter(
+            HttpAdapterFactory::factory($config['options']),
+            $services->get('authentication'),
+            $type
+        );
+    }
+}

--- a/src/Factory/AuthenticationHttpAdapterFactory.php
+++ b/src/Factory/AuthenticationHttpAdapterFactory.php
@@ -5,6 +5,7 @@
  */
 namespace ZF\MvcAuth\Factory;
 
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\MvcAuth\Authentication\HttpAdapter;
 
@@ -34,7 +35,7 @@ final class AuthenticationHttpAdapterFactory
             );
         }
 
-        if (! isset($config['options']) && ! is_array($config['options'])) {
+        if (! isset($config['options']) || ! is_array($config['options'])) {
             throw new ServiceNotCreatedException(
                 'Cannot create HTTP authentication adapter; missing options'
             );

--- a/src/Factory/AuthenticationOAuth2AdapterFactory.php
+++ b/src/Factory/AuthenticationOAuth2AdapterFactory.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+namespace ZF\MvcAuth\Factory;
+
+use MongoClient;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\MvcAuth\Authentication\OAuth2Adapter;
+
+final class AuthenticationOAuth2AdapterFactory
+{
+    /**
+     * Intentionally empty and private to prevent instantiation
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Create and return an OAuth2Adapter instance.
+     * 
+     * @param string|array $type 
+     * @param array $config 
+     * @param ServiceLocatorInterface $services 
+     * @return OAuth2Adapter
+     * @throws ServiceNotCreatedException when missing details necessary to
+     *     create instance and/or dependencies.
+     */
+    public static function factory($type, array $config, ServiceLocatorInterface $services)
+    {
+        if (! isset($config['storage']) || ! is_array($config['storage'])) {
+            throw new ServiceNotCreatedException('Missing storage details for OAuth2 server');
+        }
+
+        return new OAuth2Adapter(
+            OAuth2ServerFactory::factory($config['storage'], $services),
+            $type
+        );
+    }
+}

--- a/src/Factory/DefaultAuthHttpAdapterFactory.php
+++ b/src/Factory/DefaultAuthHttpAdapterFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2015 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\MvcAuth\Factory;
@@ -35,54 +35,6 @@ class DefaultAuthHttpAdapterFactory implements FactoryInterface
             return false;
         }
 
-        $httpConfig = $config['zf-mvc-auth']['authentication']['http'];
-
-        if (!isset($httpConfig['accept_schemes']) || !is_array($httpConfig['accept_schemes'])) {
-            throw new ServiceNotCreatedException(
-                '"accept_schemes" is required when configuring an HTTP authentication adapter'
-            );
-        }
-
-        if (!isset($httpConfig['realm'])) {
-            throw new ServiceNotCreatedException('"realm" is required when configuring an HTTP authentication adapter');
-        }
-
-        if (in_array('digest', $httpConfig['accept_schemes'])) {
-            if (!isset($httpConfig['digest_domains'])
-                || !isset($httpConfig['nonce_timeout'])
-            ) {
-                throw new ServiceNotCreatedException(
-                    'Both "digest_domains" and "nonce_timeout" are required '
-                    . 'when configuring an HTTP digest authentication adapter'
-                );
-            }
-        }
-
-        $httpAdapter = new HttpAuth(array_merge(
-            $httpConfig,
-            array(
-                'accept_schemes' => implode(' ', $httpConfig['accept_schemes'])
-            )
-        ));
-
-        if (in_array('basic', $httpConfig['accept_schemes'])
-            && $services->has('ZF\MvcAuth\ApacheResolver')
-        ) {
-            $resolver = $services->get('ZF\MvcAuth\ApacheResolver');
-            if ($resolver !== false) {
-                $httpAdapter->setBasicResolver($resolver);
-            }
-        }
-
-        if (in_array('digest', $httpConfig['accept_schemes'])
-            && $services->has('ZF\MvcAuth\FileResolver')
-        ) {
-            $resolver = $services->get('ZF\MvcAuth\FileResolver');
-            if ($resolver !== false) {
-                $httpAdapter->setDigestResolver($resolver);
-            }
-        }
-
-        return $httpAdapter;
+        return HttpAdapterFactory::factory($config['zf-mvc-auth']['authentication']['http']);
     }
 }

--- a/src/Factory/HttpAdapterFactory.php
+++ b/src/Factory/HttpAdapterFactory.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+namespace ZF\MvcAuth\Factory;
+
+use Zend\Authentication\Adapter\Http as HttpAuth;
+use Zend\Authentication\Adapter\Http\ApacheResolver;
+use Zend\Authentication\Adapter\Http\FileResolver;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+
+/**
+ * Create and return a Zend\Authentication\Adapter\Http instance based on the
+ * configuration provided.
+ */
+final class HttpAdapterFactory
+{
+    /**
+     * Only defined in order to prevent instantiation.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Create an HttpAuth instance based on the configuration passed.
+     * 
+     * @param array $config 
+     * @return HttpAuth
+     * @throws ServiceNotCreatedException if any required elements are missing
+     */
+    public static function factory(array $config)
+    {
+        if (! isset($config['accept_schemes']) || ! is_array($config['accept_schemes'])) {
+            throw new ServiceNotCreatedException(
+                '"accept_schemes" is required when configuring an HTTP authentication adapter'
+            );
+        }
+
+        if (! isset($config['realm'])) {
+            throw new ServiceNotCreatedException(
+                '"realm" is required when configuring an HTTP authentication adapter'
+            );
+        }
+
+        if (in_array('digest', $config['accept_schemes'])) {
+            if (! isset($config['digest_domains'])
+                || ! isset($config['nonce_timeout'])
+            ) {
+                throw new ServiceNotCreatedException(
+                    'Both "digest_domains" and "nonce_timeout" are required '
+                    . 'when configuring an HTTP digest authentication adapter'
+                );
+            }
+        }
+
+        $httpAdapter = new HttpAuth(array_merge(
+            $config,
+            array(
+                'accept_schemes' => implode(' ', $config['accept_schemes'])
+            )
+        ));
+
+        if (in_array('basic', $config['accept_schemes'])
+            && isset($config['htpasswd'])
+        ) {
+            $httpAdapter->setBasicResolver(new ApacheResolver($config['htpasswd']));
+        }
+
+        if (in_array('digest', $config['accept_schemes'])
+            && isset($config['htdigest'])
+        ) {
+            $httpAdapter->setDigestResolver(new FileResolver($config['htdigest']));
+        }
+
+        return $httpAdapter;
+    }
+}

--- a/src/Factory/OAuth2ServerFactory.php
+++ b/src/Factory/OAuth2ServerFactory.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+namespace ZF\MvcAuth\Factory;
+
+use MongoClient;
+use OAuth2\GrantType\AuthorizationCode;
+use OAuth2\GrantType\ClientCredentials;
+use OAuth2\Server as OAuth2Server;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\OAuth2\Adapter\MongoAdapter;
+use ZF\OAuth2\Adapter\PdoAdapter;
+
+final class OAuth2ServerFactory
+{
+    /**
+     * Intentionally empty and private to prevent instantiation
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Create and return a fully configured OAuth2 server instance.
+     * 
+     * @param array $config 
+     * @param ServiceLocatorInterface $services 
+     * @return OAuth2Server
+     * @throws ServiceNotCreatedException when missing details necessary to
+     *     create instance and/or dependencies.
+     */
+    public static function factory(array $config, ServiceLocatorInterface $services)
+    {
+        $storage = self::createStorage($config, $services);
+
+        $oauth2Server = new OAuth2Server(self::createStorage($config, $services));
+
+        // Add the "Client Credentials" grant type (it is the simplest of the grant types)
+        $oauth2Server->addGrantType(new ClientCredentials($storage));
+
+        // Add the "Authorization Code" grant type
+        $oauth2Server->addGrantType(new AuthorizationCode($storage));
+
+        return $oauth2Server;
+    }
+
+    /**
+     * Create and return an OAuth2 storage adapter instance.
+     * 
+     * @param array $config 
+     * @param ServiceLocatorInterface $services 
+     * @return PdoAdapter|MongoAdapter
+     */
+    private static function createStorage(array $config, ServiceLocatorInterface $services)
+    {
+        if (! isset($config['adapter']) || ! is_string($config['adapter'])) {
+            throw new ServiceNotCreatedException(
+                'Missing or invalid storage adapter information for OAuth2'
+            );
+        }
+
+        switch (strtolower($config['adapter'])) {
+            case 'pdo':
+                return self::createPdoAdapter($config);
+            case 'mongo':
+                return self::createMongoAdapter($config, $services);
+            default:
+                throw new ServiceNotCreatedException('Invalid storage adapter type for OAuth2');
+        }
+    }
+
+    /**
+     * Create and return an OAuth2 PDO adapter.
+     * 
+     * @param array $config 
+     * @return PdoAdapter
+     */
+    private static function createPdoAdapter(array $config)
+    {
+        return new PdoAdapter(
+            self::createPdoConfig($config),
+            self::getOAuth2ServerConfig($config)
+        );
+    }
+
+    /**
+     * Create and return an OAuth2 Mongo adapter.
+     * 
+     * @param array $config 
+     * @param ServiceLocatorInterface $services 
+     * @return MongoAdapter
+     */
+    private static function createMongoAdapter(array $config, ServiceLocatorInterface $services)
+    {
+        return new MongoAdapter(
+            self::createMongoDatabase($config, $services),
+            self::getOAuth2ServerConfig($config)
+        );
+    }
+
+    /**
+     * Create and return the configuration needed to create a PDO instance.
+     * 
+     * @param array $config 
+     * @return array
+     */
+    private static function createPdoConfig(array $config)
+    {
+        if (! isset($config['dsn'])) {
+            throw new ServiceNotCreatedException(
+                'Missing DSN for OAuth2 PDO adapter creation'
+            );
+        }
+
+        $username = isset($config['username']) ? $config['username'] : null;
+        $password = isset($config['password']) ? $config['password'] : null;
+        $options  = isset($config['options'])  ? $config['options'] : array();
+
+        return array(
+            'dsn'      => $config['dsn'],
+            'username' => $username,
+            'password' => $password,
+            'options'  => $options,
+        );
+    }
+
+    /**
+     * Create and return a Mongo database instance.
+     * 
+     * @param array $config 
+     * @param ServiceLocatorInterface $services 
+     * @return \MongoDB
+     */
+    private static function createMongoDatabase(array $config, ServiceLocatorInterface $services)
+    {
+        $dbLocatorName = isset($config['locator_name'])
+            ? $config['locator_name']
+            : 'MongoDB';
+
+        if ($services->has($dbLocatorName)) {
+            return $services->get($dbLocatorName);
+        }
+
+        if (! isset($config['database'])) {
+            throw new ServiceNotCreatedException(
+                'Missing OAuth2 Mongo database configuration'
+            );
+        }
+
+        $options = isset($config['options']) ? $config['options'] : array();
+        $options['connect'] = false;
+        $server  = isset($config['dsn']) ? $config['dsn'] : null;
+        $mongo   = new MongoClient($server, $options);
+        return $mongo->{$config['database']};
+    }
+
+    /**
+     * Retrieve oauth2-server-php storage settings configuration.
+     *
+     * @return array
+     */
+    private static function getOAuth2ServerConfig($config)
+    {
+        $oauth2ServerConfig = array();
+        if (isset($config['storage_settings']) && is_array($config['storage_settings'])) {
+            $oauth2ServerConfig = $config['storage_settings'];
+        }
+
+        return $oauth2ServerConfig;
+    }
+}

--- a/test/Factory/AuthenticationAdapterDelegatorFactoryTest.php
+++ b/test/Factory/AuthenticationAdapterDelegatorFactoryTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\MvcAuth\Factory;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\ServiceManager\ServiceManager;
+use ZF\MvcAuth\Authentication\DefaultAuthenticationListener;
+use ZF\MvcAuth\Factory\AuthenticationAdapterDelegatorFactory;
+
+class AuthenticationAdapterDelegatorFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        // Actual service manager instance, as multiple services may be
+        // requested; simplifies testing.
+        $this->services = new ServiceManager();
+        $this->factory  = new AuthenticationAdapterDelegatorFactory();
+        $this->listener = $listener = new DefaultAuthenticationListener();
+        $this->callback = function () use ($listener) {
+            return $listener;
+        };
+    }
+
+    public function testReturnsListenerWithNoAdaptersWhenNoAdaptersAreInConfiguration()
+    {
+        $config = array();
+        $this->services->setService('Config', $config);
+
+        $listener = $this->factory->createDelegatorWithName(
+            $this->services,
+            'ZF\MvcAuth\Authentication\DefaultAuthenticationListener',
+            'ZF\MvcAuth\Authentication\DefaultAuthenticationListener',
+            $this->callback
+        );
+        $this->assertSame($this->listener, $listener);
+        $this->assertEquals(array(), $listener->getAuthenticationTypes());
+    }
+
+
+    public function testReturnsListenerWithConfiguredAdapters()
+    {
+        $config = array(
+            'zf-mvc-auth' => array(
+                'authentication' => array(
+                    'adapters' => array(
+                        'foo' => array(
+                            'adapter' => 'ZF\MvcAuth\Authentication\HttpAdapter',
+                            'options' => array(
+                                'accept_schemes' => array('basic'),
+                                'realm' => 'api',
+                                'htpasswd' => __DIR__ . '/../TestAsset/htpasswd',
+                            ),
+                        ),
+                        'bar' => array(
+                            'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
+                            'storage' => array(
+                                'adapter' => 'pdo',
+                                'dsn' => 'sqlite:memory:',
+                            ),
+                        ),
+                        'baz' => array(
+                            'adapter' => 'UNKNOWN',
+                        ),
+                        'bat' => array(
+                            // intentionally empty
+                        ),
+                    ),
+                ),
+            ),
+        );
+        $this->services->setService('Config', $config);
+        $this->services->setService('authentication', $this->getMock('Zend\Authentication\AuthenticationService'));
+
+        $listener = $this->factory->createDelegatorWithName(
+            $this->services,
+            'ZF\MvcAuth\Authentication\DefaultAuthenticationListener',
+            'ZF\MvcAuth\Authentication\DefaultAuthenticationListener',
+            $this->callback
+        );
+        $this->assertSame($this->listener, $listener);
+        $this->assertEquals(array(
+            'foo-basic',
+            'bar'
+        ), $listener->getAuthenticationTypes());
+    }
+}

--- a/test/Factory/AuthenticationHttpAdapterFactoryTest.php
+++ b/test/Factory/AuthenticationHttpAdapterFactoryTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\MvcAuth\Factory;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZF\MvcAuth\Factory\AuthenticationHttpAdapterFactory;
+
+class AuthenticationHttpAdapterFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->services = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+    }
+
+    public function testRaisesExceptionIfNoAuthenticationServicePresent()
+    {
+        $this->services->expects($this->atLeastOnce())
+            ->method('has')
+            ->with($this->equalTo('authentication'))
+            ->will($this->returnValue(false));
+
+        $this->setExpectedException(
+            'Zend\ServiceManager\Exception\ServiceNotCreatedException',
+            'missing AuthenticationService'
+        );
+        AuthenticationHttpAdapterFactory::factory('foo', array(), $this->services);
+    }
+
+    public function invalidConfiguration()
+    {
+        return array(
+            'empty'  => array(array()),
+            'null'   => array(array('options' => null)),
+            'bool'   => array(array('options' => true)),
+            'int'    => array(array('options' => 1)),
+            'float'  => array(array('options' => 1.1)),
+            'string' => array(array('options' => 'options')),
+            'object' => array(array('options' => (object) array('options'))),
+        );
+    }
+
+    /**
+     * @dataProvider invalidConfiguration
+     */
+    public function testRaisesExceptionIfMissingConfigurationOptions($config)
+    {
+        $this->services->expects($this->atLeastOnce())
+            ->method('has')
+            ->with($this->equalTo('authentication'))
+            ->will($this->returnValue(true));
+
+        $this->setExpectedException(
+            'Zend\ServiceManager\Exception\ServiceNotCreatedException',
+            'missing options'
+        );
+        AuthenticationHttpAdapterFactory::factory('foo', $config, $this->services);
+    }
+
+    public function validConfiguration()
+    {
+        return array(
+            'basic' => array(array(
+                'accept_schemes' => array('basic'),
+                'realm' => 'api',
+                'htpasswd' => __DIR__ . '/../TestAsset/htpasswd',
+            ), array('foo-basic')),
+            'digest' => array(array(
+                'accept_schemes' => array('digest'),
+                'realm' => 'api',
+                'digest_domains' => 'https://example.com',
+                'nonce_timeout' => 3600,
+                'htdigest' => __DIR__ . '/../TestAsset/htdigest',
+            ), array('foo-digest')),
+            'both' => array(array(
+                'accept_schemes' => array('basic', 'digest'),
+                'realm' => 'api',
+                'digest_domains' => 'https://example.com',
+                'nonce_timeout' => 3600,
+                'htpasswd' => __DIR__ . '/../TestAsset/htpasswd',
+                'htdigest' => __DIR__ . '/../TestAsset/htdigest',
+            ), array('foo-basic', 'foo-digest')),
+        );
+    }
+
+    /**
+     * @dataProvider validConfiguration
+     */
+    public function testCreatesHttpAdapterWhenConfigurationIsValid(array $options, array $provides)
+    {
+        $authService = $this->getMock('Zend\Authentication\AuthenticationService');
+        $this->services->expects($this->atLeastOnce())
+            ->method('has')
+            ->with($this->equalTo('authentication'))
+            ->will($this->returnValue(true));
+        $this->services->expects($this->atLeastOnce())
+            ->method('get')
+            ->with($this->equalTo('authentication'))
+            ->will($this->returnValue($authService));
+
+        $adapter = AuthenticationHttpAdapterFactory::factory('foo', array('options' => $options), $this->services);
+        $this->assertInstanceOf('ZF\MvcAuth\Authentication\HttpAdapter', $adapter);
+        $this->assertEquals($provides, $adapter->provides());
+    }
+}

--- a/test/Factory/AuthenticationOAuth2AdapterFactoryTest.php
+++ b/test/Factory/AuthenticationOAuth2AdapterFactoryTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\MvcAuth\Factory;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZF\MvcAuth\Factory\AuthenticationOAuth2AdapterFactory;
+
+class AuthenticationOAuth2AdapterFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->services = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+    }
+
+
+    public function invalidConfiguration()
+    {
+        return array(
+            'empty'  => array(array()),
+            'null'   => array(array('storage' => null)),
+            'bool'   => array(array('storage' => true)),
+            'int'    => array(array('storage' => 1)),
+            'float'  => array(array('storage' => 1.1)),
+            'string' => array(array('storage' => 'options')),
+            'object' => array(array('storage' => (object) array('storage'))),
+        );
+    }
+
+    /**
+     * @dataProvider invalidConfiguration
+     */
+    public function testRaisesExceptionForMissingOrInvalidStorage(array $config)
+    {
+        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotCreatedException', 'Missing storage');
+        AuthenticationOAuth2AdapterFactory::factory('foo', $config, $this->services);
+    }
+
+    public function testCreatesInstanceFromValidConfiguration()
+    {
+        $config = array(
+            'adapter' => 'pdo',
+            'storage' => array(
+                'adapter' => 'pdo',
+                'dsn' => 'sqlite:memory:',
+            ),
+        );
+        $adapter = AuthenticationOAuth2AdapterFactory::factory('foo', $config, $this->services);
+        $this->assertInstanceOf('ZF\MvcAuth\Authentication\OAuth2Adapter', $adapter);
+        $this->assertEquals(array('foo'), $adapter->provides());
+    }
+}

--- a/test/Factory/HttpAdapterFactoryTest.php
+++ b/test/Factory/HttpAdapterFactoryTest.php
@@ -1,0 +1,164 @@
+<?php
+namespace ZFTest\MvcAuth\Factory;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZF\MvcAuth\Factory\HttpAdapterFactory;
+
+class HttpAdapterFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->htpasswd = __DIR__ . '/../TestAsset/htpasswd';
+        $this->htdigest = __DIR__ . '/../TestAsset/htdigest';
+    }
+
+    public function testFactoryRaisesExceptionWhenNoAcceptSchemesPresent()
+    {
+        $this->setExpectedException(
+            'Zend\ServiceManager\Exception\ServiceNotCreatedException',
+            'accept_schemes'
+        );
+        HttpAdapterFactory::factory(array());
+    }
+
+    public function invalidAcceptSchemes()
+    {
+        return array(
+            'null' => array(null),
+            'true' => array(true),
+            'false' => array(false),
+            'zero' => array(0),
+            'int' => array(1),
+            'zerofloat' => array(0.0),
+            'float' => array(1.1),
+            'string' => array('basic'),
+            'object' => array((object) array('basic')),
+        );
+    }
+
+    /**
+     * @dataProvider invalidAcceptSchemes
+     */
+    public function testFactoryRaisesExceptionWhenAcceptSchemesIsNotAnArray($acceptSchemes)
+    {
+        $this->setExpectedException(
+            'Zend\ServiceManager\Exception\ServiceNotCreatedException',
+            'accept_schemes'
+        );
+        HttpAdapterFactory::factory(array('accept_schemes' => $acceptSchemes));
+    }
+
+    public function testFactoryRaisesExceptionWhenRealmIsMissing()
+    {
+        $this->setExpectedException(
+            'Zend\ServiceManager\Exception\ServiceNotCreatedException',
+            'realm'
+        );
+        HttpAdapterFactory::factory(array(
+            'accept_schemes' => array('basic'),
+        ));
+    }
+
+    public function testRaisesExceptionWhenDigestConfiguredAndNoDomainsPresent()
+    {
+        $this->setExpectedException(
+            'Zend\ServiceManager\Exception\ServiceNotCreatedException',
+            'digest_domains'
+        );
+        HttpAdapterFactory::factory(array(
+            'accept_schemes' => array('digest'),
+            'realm' => 'api',
+            'nonce_timeout' => 3600,
+        ));
+    }
+
+    public function testRaisesExceptionWhenDigestConfiguredAndNoNoncePresent()
+    {
+        $this->setExpectedException(
+            'Zend\ServiceManager\Exception\ServiceNotCreatedException',
+            'digest_domains'
+        );
+        HttpAdapterFactory::factory(array(
+            'accept_schemes' => array('digest'),
+            'realm' => 'api',
+            'digest_domains' => 'https://example.com',
+        ));
+    }
+
+    public function validConfigWithoutResolvers()
+    {
+        return array(
+            'basic' => array(array(
+                'accept_schemes' => array('basic'),
+                'realm' => 'api',
+            )),
+            'digest' => array(array(
+                'accept_schemes' => array('digest'),
+                'realm' => 'api',
+                'digest_domains' => 'https://example.com',
+                'nonce_timeout' => 3600,
+            )),
+            'both' => array(array(
+                'accept_schemes' => array('basic', 'digest'),
+                'realm' => 'api',
+                'digest_domains' => 'https://example.com',
+                'nonce_timeout' => 3600,
+            )),
+        );
+    }
+
+    /**
+     * @dataProvider validConfigWithoutResolvers
+     */
+    public function testCanReturnAdapterWithNoResolvers($config)
+    {
+        $adapter = HttpAdapterFactory::factory($config);
+        $this->assertInstanceOf('Zend\Authentication\Adapter\Http', $adapter);
+        $this->assertNull($adapter->getBasicResolver());
+        $this->assertNull($adapter->getDigestResolver());
+    }
+
+    public function testCanReturnBasicAdapterWithApacheResolver()
+    {
+        $adapter = HttpAdapterFactory::factory(array(
+            'accept_schemes' => array('basic'),
+            'realm' => 'api',
+            'htpasswd' => $this->htpasswd,
+        ));
+
+        $this->assertInstanceOf('Zend\Authentication\Adapter\Http', $adapter);
+        $this->assertInstanceOf('Zend\Authentication\Adapter\Http\ApacheResolver', $adapter->getBasicResolver());
+        $this->assertNull($adapter->getDigestResolver());
+    }
+
+    public function testCanReturnDigestAdapterWithFileResolver()
+    {
+        $adapter = HttpAdapterFactory::factory(array(
+            'accept_schemes' => array('digest'),
+            'realm' => 'api',
+            'digest_domains' => 'https://example.com',
+            'nonce_timeout' => 3600,
+            'htdigest' => $this->htdigest,
+        ));
+
+        $this->assertInstanceOf('Zend\Authentication\Adapter\Http', $adapter);
+        $this->assertNull($adapter->getBasicResolver());
+        $this->assertInstanceOf('Zend\Authentication\Adapter\Http\FileResolver', $adapter->getDigestResolver());
+    }
+
+    public function testCanReturnCompoundAdapter()
+    {
+        $adapter = HttpAdapterFactory::factory(array(
+            'accept_schemes' => array('basic', 'digest'),
+            'realm' => 'api',
+            'digest_domains' => 'https://example.com',
+            'nonce_timeout' => 3600,
+            'htpasswd' => $this->htpasswd,
+            'htdigest' => $this->htdigest,
+        ));
+
+        $this->assertInstanceOf('Zend\Authentication\Adapter\Http', $adapter);
+        $this->assertInstanceOf('Zend\Authentication\Adapter\Http\ApacheResolver', $adapter->getBasicResolver());
+        $this->assertInstanceOf('Zend\Authentication\Adapter\Http\FileResolver', $adapter->getDigestResolver());
+    }
+}

--- a/test/Factory/HttpAdapterFactoryTest.php
+++ b/test/Factory/HttpAdapterFactoryTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
 namespace ZFTest\MvcAuth\Factory;
 
 use PHPUnit_Framework_TestCase as TestCase;

--- a/test/Factory/OAuth2ServerFactoryTest.php
+++ b/test/Factory/OAuth2ServerFactoryTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\MvcAuth\Factory;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZF\MvcAuth\Factory\OAuth2ServerFactory;
+
+class OAuth2ServerFactoryTest extends TestCase
+{
+    public function testRaisesExceptionIfAdapterIsMissing()
+    {
+        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotCreatedException', 'storage adapter');
+        $services = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $config = array(
+            'dsn' => 'sqlite:memory:',
+        );
+        $server = OAuth2ServerFactory::factory($config, $services);
+    }
+
+    public function testRaisesExceptionCreatingPdoBackedServerIfDsnIsMissing()
+    {
+        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotCreatedException', 'Missing DSN');
+        $services = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $config = array(
+            'adapter' => 'pdo',
+            'username' => 'username',
+            'password' => 'password',
+        );
+        $server = OAuth2ServerFactory::factory($config, $services);
+        $this->assertInstanceOf('OAuth2\Server', $server);
+    }
+
+    public function testCanCreatePdoAdapterBackedServer()
+    {
+        $services = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $config = array(
+            'adapter' => 'pdo',
+            'dsn' => 'sqlite:memory:',
+        );
+        $server = OAuth2ServerFactory::factory($config, $services);
+        $this->assertInstanceOf('OAuth2\Server', $server);
+    }
+
+    public function testCanCreateMongoBackedServerUsingMongoFromServices()
+    {
+        if (! class_exists('MongoDB')) {
+            $this->markTestSkipped('Mongo extension is required for this test');
+        }
+
+        $mongoClient = $this->getMockBuilder('MongoDB')
+            ->disableOriginalConstructor(true)
+            ->getMock();
+        $services = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $services->expects($this->atLeastOnce())
+            ->method('has')
+            ->with($this->equalTo('MongoService'))
+            ->will($this->returnValue(true));
+        $services->expects($this->atLeastOnce())
+            ->method('get')
+            ->with($this->equalTo('MongoService'))
+            ->will($this->returnValue($mongoClient));
+
+        $config = array(
+            'adapter' => 'mongo',
+            'locator_name' => 'MongoService',
+        );
+        $server = OAuth2ServerFactory::factory($config, $services);
+        $this->assertInstanceOf('OAuth2\Server', $server);
+    }
+
+    public function testRaisesExceptionCreatingMongoBackedServerIfDatabaseIsMissing()
+    {
+        $services = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $config = array(
+            'adapter' => 'mongo',
+        );
+
+        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotCreatedException', 'database');
+        $server = OAuth2ServerFactory::factory($config, $services);
+    }
+
+    public function testCanCreateMongoAdapterBackedServer()
+    {
+        if (! class_exists('MongoDB')) {
+            $this->markTestSkipped('Mongo extension is required for this test');
+        }
+
+        $services = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $config = array(
+            'adapter' => 'mongo',
+            'database' => 'zf-mvc-auth-test',
+        );
+        $server = OAuth2ServerFactory::factory($config, $services);
+        $this->assertInstanceOf('OAuth2\Server', $server);
+    }
+}


### PR DESCRIPTION
Now that #59 is merged, another suggested improvement is to allow having multiple HTTP and/or OAuth2 configurations. This would allow different APIs and/or versions of APIs to have separate configuration and users.

The idea floated currently is to provide a special configuration key under which mapped types => configurations exist; a Delegator Factory would then loop through these, create adapters, and attach them to the `DefaultAuthenticationListener`.