### PR TITLE
Fixes for HTTP authentication adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,15 @@ interface AdapterInterface
     public function provides();
 
     /**
+     * Attempt to match a requested authentication type
+     * against what the adapter provides.
+     *
+     * @param string $type
+     * @return bool
+     */
+    public function matches($type);
+
+    /**
      * Attempt to retrieve the authentication type based on the request.
      *
      * Allows an adapter to have custom logic for detecting if a request
@@ -527,6 +536,10 @@ interface AdapterInterface
 The `provides()` method should return an array of strings, each an
 authentication "type" that this adapter provides; as an example, the provided
 `ZF\MvcAuth\Authentication\HttpAdapter` can provide `basic` and/or `digest`.
+
+The `matches($type)` should test the given `$type` against what the adapter
+provides to determine if it can handle an authentication request. Typically,
+this can be done with `return in_array($type, $this->provides(), true);`
 
 The `getTypeFromRequest()` method can be used to match an incoming request to
 the authentication type it resolves, if any. Examples might be deconstructing

--- a/src/Authentication/AdapterInterface.php
+++ b/src/Authentication/AdapterInterface.php
@@ -19,6 +19,15 @@ interface AdapterInterface
     public function provides();
 
     /**
+     * Attempt to match a requested authentication type
+     * against what the adapter provides.
+     *
+     * @param string $type
+     * @return bool
+     */
+    public function matches($type);
+
+    /**
      * Attempt to retrieve the authentication type based on the request.
      *
      * Allows an adapter to have custom logic for detecting if a request

--- a/src/Authentication/DefaultAuthenticationListener.php
+++ b/src/Authentication/DefaultAuthenticationListener.php
@@ -19,21 +19,21 @@ class DefaultAuthenticationListener
 {
     /**
      * Attached authentication adapters
-     * 
+     *
      * @var AdapterInterface[]
      */
     private $adapters = array();
 
     /**
      * Supported authentication types
-     * 
+     *
      * @var array
      */
     private $authenticationTypes = array();
 
     /**
      * Map of API/version to authentication type pairs
-     * 
+     *
      * @var array
      */
     private $authMap = array();
@@ -54,8 +54,8 @@ class DefaultAuthenticationListener
      *
      * Adds the authentication adapter, and updates the list of supported
      * authentication types based on what the adapter provides.
-     * 
-     * @param AdapterInterface $adapter 
+     *
+     * @param AdapterInterface $adapter
      */
     public function attach(AdapterInterface $adapter)
     {
@@ -69,8 +69,8 @@ class DefaultAuthenticationListener
      * This method allows specifiying additional authentication types, outside
      * of adapters, that your application supports. The values provided are
      * merged with any types already discovered.
-     * 
-     * @param array $types 
+     *
+     * @param array $types
      */
     public function addAuthenticationTypes(array $types)
     {
@@ -84,7 +84,7 @@ class DefaultAuthenticationListener
 
     /**
      * Retrieve the supported authentication types
-     * 
+     *
      * @return array
      */
     public function getAuthenticationTypes()
@@ -135,8 +135,8 @@ class DefaultAuthenticationListener
 
     /**
      * Set the API/version to authentication type map.
-     * 
-     * @param array $map 
+     *
+     * @param array $map
      */
     public function setAuthMap(array $map)
     {
@@ -195,10 +195,10 @@ class DefaultAuthenticationListener
     }
 
     /**
-     * Match the controller to an authentication type, based on the API to 
+     * Match the controller to an authentication type, based on the API to
      * which the controller belongs.
-     * 
-     * @param null|RouteMatch $routeMatch 
+     *
+     * @param null|RouteMatch $routeMatch
      * @return string|false
      */
     private function getTypeFromMap(RouteMatch $routeMatch = null)
@@ -228,8 +228,8 @@ class DefaultAuthenticationListener
 
     /**
      * Determine the authentication type based on request information
-     * 
-     * @param HttpRequest $request 
+     *
+     * @param HttpRequest $request
      * @return false|string
      */
     private function getTypeFromRequest(HttpRequest $request)
@@ -248,9 +248,9 @@ class DefaultAuthenticationListener
      *
      * This method is triggered if no authentication type was discovered in the
      * request.
-     * 
-     * @param HttpRequest $request 
-     * @param HttpResponse $response 
+     *
+     * @param HttpRequest $request
+     * @param HttpResponse $response
      */
     private function triggerAdapterPreAuth(HttpRequest $request, HttpResponse $response)
     {
@@ -261,17 +261,17 @@ class DefaultAuthenticationListener
 
     /**
      * Invoke the adapter matching the given $type in order to peform authentication
-     * 
-     * @param string $type 
-     * @param HttpRequest $request 
-     * @param HttpResponse $response 
-     * @param MvcAuthEvent $mvcAuthEvent 
+     *
+     * @param string $type
+     * @param HttpRequest $request
+     * @param HttpResponse $response
+     * @param MvcAuthEvent $mvcAuthEvent
      * @return false|Identity\IdentityInterface
      */
     private function authenticate($type, HttpRequest $request, HttpResponse $response, MvcAuthEvent $mvcAuthEvent)
     {
         foreach ($this->adapters as $adapter) {
-            if (! in_array($type, $adapter->provides(), true)) {
+            if (! $adapter->matches($type)) {
                 continue;
             }
 
@@ -284,11 +284,11 @@ class DefaultAuthenticationListener
     /**
      * Attach the $httpAdapter as a proper adapter
      *
-     * This is to allow using the setHttpAdapter() method along with the 
+     * This is to allow using the setHttpAdapter() method along with the
      * AdapterInterface system, and will be removed in a future version.
-     * 
+     *
      * @deprecated
-     * @param MvcAuthEvent $mvcAuthEvent 
+     * @param MvcAuthEvent $mvcAuthEvent
      */
     private function attachHttpAdapter(MvcAuthEvent $mvcAuthEvent)
     {

--- a/src/Authentication/HttpAdapter.php
+++ b/src/Authentication/HttpAdapter.php
@@ -22,7 +22,7 @@ class HttpAdapter extends AbstractAdapter
 
     /**
      * Authorization header token types this adapter can fulfill.
-     * 
+     *
      * @var array
      */
     protected $authorizationTokenTypes = array('basic', 'digest');
@@ -34,7 +34,7 @@ class HttpAdapter extends AbstractAdapter
 
     /**
      * Base to use when prefixing "provides" strings
-     * 
+     *
      * @var null|string
      */
     private $providesBase;
@@ -81,6 +81,17 @@ class HttpAdapter extends AbstractAdapter
         }
 
         return $provides;
+    }
+
+    /**
+     * Match the requested authentication type against what we provide.
+     *
+     * @param string $type
+     * @return bool
+     */
+    public function matches($type)
+    {
+        return ($this->providesBase === $type || in_array($type, $this->provides(), true));
     }
 
     /**

--- a/src/Authentication/OAuth2Adapter.php
+++ b/src/Authentication/OAuth2Adapter.php
@@ -17,7 +17,7 @@ class OAuth2Adapter extends AbstractAdapter
 {
     /**
      * Authorization header token types this adapter can fulfill.
-     * 
+     *
      * @var array
      */
     protected $authorizationTokenTypes = array('bearer');
@@ -29,7 +29,7 @@ class OAuth2Adapter extends AbstractAdapter
 
     /**
      * Authentication types this adapter provides.
-     * 
+     *
      * @var array
      */
     private $providesTypes = array('oauth2');
@@ -67,6 +67,18 @@ class OAuth2Adapter extends AbstractAdapter
     public function provides()
     {
         return $this->providesTypes;
+    }
+
+    /**
+     * Attempt to match a requested authentication type
+     * against what the adapter provides.
+     *
+     * @param string $type
+     * @return bool
+     */
+    public function matches($type)
+    {
+        return in_array($type, $this->providesTypes, true);
     }
 
     /**

--- a/src/Factory/DefaultAuthenticationListenerFactory.php
+++ b/src/Factory/DefaultAuthenticationListenerFactory.php
@@ -48,6 +48,8 @@ class DefaultAuthenticationListenerFactory implements FactoryInterface
             $listener->addAuthenticationTypes($authenticationTypes);
         }
 
+        $listener->setAuthMap($this->getAuthenticationMap($services));
+
         return $listener;
     }
 
@@ -145,5 +147,21 @@ class DefaultAuthenticationListenerFactory implements FactoryInterface
         }
 
         return $config['zf-mvc-auth']['authentication']['types'];
+    }
+
+    protected function getAuthenticationMap(ServiceLocatorInterface $services)
+    {
+        if (! $services->has('config')) {
+            return array();
+        }
+
+        $config = $services->get('config');
+        if (! isset($config['zf-mvc-auth']['authentication']['map'])
+            || ! is_array($config['zf-mvc-auth']['authentication']['map'])
+        ) {
+            return array();
+        }
+
+        return $config['zf-mvc-auth']['authentication']['map'];
     }
 }

--- a/test/Authentication/DefaultAuthenticationListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationListenerTest.php
@@ -688,6 +688,10 @@ class DefaultAuthenticationListenerTest extends TestCase
             ->method('getTypeFromRequest')
             ->with($this->equalTo($request))
             ->will($this->returnValue('oauth2'));
+        $adapter->expects($this->any())
+            ->method('matches')
+            ->with($this->equalTo('oauth2'))
+            ->will($this->returnValue(true));
         $expected = $this->getMockBuilder('ZF\MvcAuth\Identity\AuthenticatedIdentity')
             ->disableOriginalConstructor()
             ->getMock();
@@ -723,6 +727,10 @@ class DefaultAuthenticationListenerTest extends TestCase
         $adapter1->expects($this->atLeastOnce())
             ->method('provides')
             ->will($this->returnValue($types));
+        $adapter1->expects($this->any())
+            ->method('matches')
+            ->with($this->equalTo('oauth2'))
+            ->will($this->returnValue(true));
         $adapter1->expects($this->any())
             ->method('getTypeFromRequest')
             ->with($this->equalTo($request))

--- a/test/Factory/DefaultAuthenticationListenerFactoryTest.php
+++ b/test/Factory/DefaultAuthenticationListenerFactoryTest.php
@@ -174,7 +174,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $this->assertContains('digest', $listener->getAuthenticationTypes());
     }
 
-    public function testCallingFactoryWithCustomAuthenticatinTypesReturnsListenerComposingThem()
+    public function testCallingFactoryWithCustomAuthenticationTypesReturnsListenerComposingThem()
     {
         $authenticationService = $this->getMock('Zend\Authentication\AuthenticationServiceInterface');
         $this->services->setService('authentication', $authenticationService);
@@ -223,5 +223,23 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $adapter = array_shift($adapters);
         $this->assertInstanceOf('ZF\MvcAuth\Authentication\OAuth2Adapter', $adapter);
         $this->assertAttributeSame($oauth2Server, 'oauth2Server', $adapter);
+    }
+
+    public function testCallingFactoryWithAuthenticationMapReturnsListenerComposingMap()
+    {
+        $authenticationService = $this->getMock('Zend\Authentication\AuthenticationServiceInterface');
+        $this->services->setService('authentication', $authenticationService);
+        $this->services->setService('config', array(
+            'zf-mvc-auth' => array(
+                'authentication' => array(
+                    'map' => array(
+                        'Testing\V1' => 'oauth2',
+                    ),
+                ),
+            ),
+        ));
+        $listener = $this->factory->createService($this->services);
+        $this->assertInstanceOf('ZF\MvcAuth\Authentication\DefaultAuthenticationListener', $listener);
+        $this->assertAttributeEquals(array('Testing\V1' => 'oauth2'), 'authMap', $listener);
     }
 }


### PR DESCRIPTION
In integration testing, I discovered that HTTP authentication was not matching as expected. The root causes were:

- authentication map data was not being injected into the `DefaultAuthenticationListener`.
- if the map included the adapter name, but the adapter supported HTTP, the adapter could not be selected.
- if the map included the adapter name and HTTP authentication type, the adapter would not be matched once authentication was ready to occur.

The solutions were:

- Functionality was added to the `DefaultAuthenticationListenerFactory` to ensure authentication maps are injected.
- The method `matches($type)` was added to the `AdapterInterface`; the `DefaultAuthenticationListener` now calls this when retrieving the adapter during authentication.
- The `HttpAdapter`'s `matches()` method was written to allow matching on just the adapter name, as well as with the `-basic` and `-digest` suffixes.

Tests were added, and integration testing with the admin UI was performed.