### PR TITLE
Normalize RPC action names when defining ACL resources

### DIFF
--- a/src/Factory/AclAuthorizationFactory.php
+++ b/src/Factory/AclAuthorizationFactory.php
@@ -89,6 +89,7 @@ class AclAuthorizationFactory implements FactoryInterface
     {
         if (isset($privileges['actions'])) {
             foreach ($privileges['actions'] as $action => $methods) {
+                $action = lcfirst($action);
                 $aclConfig[] = array(
                     'resource'   => sprintf('%s::%s', $controllerService, $action),
                     'privileges' => $this->createPrivilegesFromMethods($methods, $denyByDefault),

--- a/test/Factory/AclAuthorizationFactoryTest.php
+++ b/test/Factory/AclAuthorizationFactoryTest.php
@@ -204,4 +204,26 @@ class AclAuthorizationFactoryTest extends TestCase
         $this->assertTrue($acl->isAllowed('guest', 'Foo\Bar\RpcController::do', 'PATCH'));
         $this->assertTrue($acl->isAllowed('guest', 'Foo\Bar\RpcController::do', 'DELETE'));
     }
+
+    public function testRpcActionsAreNormalizedWhenCreatingAcl()
+    {
+        $config = array('zf-mvc-auth' => array('authorization' => array(
+            'Foo\Bar\RpcController' => array(
+                'actions' => array(
+                    'Do' => array(
+                        'GET'    => false,
+                        'POST'   => true,
+                        'PUT'    => false,
+                        'PATCH'  => false,
+                        'DELETE' => false,
+                    ),
+                ),
+            ),
+        )));
+        $this->services->setService('config', $config);
+
+        $acl = $this->factory->createService($this->services);
+        $this->assertInstanceOf('ZF\MvcAuth\Authorization\AclAuthorization', $acl);
+        $this->assertFalse($acl->isAllowed('guest', 'Foo\Bar\RpcController::do', 'POST'));
+    }
 }


### PR DESCRIPTION
As reported on the list, and independently verified, starting with 1.1.0, the admin UI does not normalize the action names when creating authorizations. As a result, ACL assertions against RPC authorizations created against >=1.1.0 always pass (unless `deny_by_default` is enabled, when they always fail). This patch normalizes the action name using `lcfirst()` before creating the ACL resource, and provides a test for the behavior.