### PR TITLE
Cache results of the NamedOAuth2ServerFactory

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -56,10 +56,30 @@ return array(
             ),
              *
              * Starting in 1.1, we have an "adapters" key, which is a key/value
-             * pair of adapter name -> adapter configuration information. This
-             * looks like the following for the HTTP basic/digest and OAuth2
+             * pair of adapter name -> adapter configuration information. Each
+             * adapter should name the ZF\MvcAuth\Authentication\AdapterInterface
+             * type in the 'adapter' key.
+             *
+             * For HttpAdapter cases, specify an 'options' key with the options
+             * to use to create the Zend\Authentication\Adapter\Http instance.
+             *
+             * For OAuth2Adapter instances, specify a 'storage' key, with options
+             * to use for matching the adapter and creating an OAuth2 storage 
+             * instance. The array MUST contain a `route' key, with the route
+             * at which the specific adapter will match authentication requests.
+             * To specify the storage instance, you may use one of two approaches:
+             *
+             * - Specify a "storage" subkey pointing to a named service or an array
+             *   of named services to use.
+             * - Specify an "adapter" subkey with the value "pdo" or "mongo", and
+             *   include additional subkeys for configuring a ZF\OAuth2\Adapter\PdoAdapter
+             *   or ZF\OAuth2\Adapter\MongoAdapter, accordingly. See the zf-oauth2
+             *   documentation for details.
+             *
+             * This looks like the following for the HTTP basic/digest and OAuth2
              * adapters:
             'adapters' => array
+                // HTTP adapter
                 'api' => array(
                     'adapter' => 'ZF\MvcAuth\Authentication\HttpAdapter',
                     'options' => array(
@@ -71,10 +91,12 @@ return array(
                         'htdigest' => 'data/htdigest',
                     ),
                 ),
+                // OAuth2 adapter, using an "adapter" type of "pdo"
                 'user' => array(
                     'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
                     'storage' => array(
                         'adapter' => 'pdo',
+                        'route' => '/user',
                         'dsn' => 'mysql:host=localhost;dbname=oauth2',
                         'username' => 'username',
                         'password' => 'password',
@@ -83,10 +105,12 @@ return array(
                         ),
                     ),
                 ),
+                // OAuth2 adapter, using an "adapter" type of "mongo"
                 'client' => array(
                     'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
                     'storage' => array(
                         'adapter' => 'mongo',
+                        'route' => '/client',
                         'locator_name' => 'SomeServiceName', // If provided, pulls the given service
                         'dsn' => 'mongodb://localhost',
                         'database' => 'oauth2',
@@ -95,6 +119,14 @@ return array(
                             'password' => 'password',
                             'connectTimeoutMS' => 500,
                         ),
+                    ),
+                ),
+                // OAuth2 adapter, using a named "storage" service
+                'named-storage' => array(
+                    'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
+                    'storage' => array(
+                        'storage' => 'Name\Of\An\OAuth2\Storage\Service',
+                        'route' => '/named-storage',
                     ),
                 ),
             ),

--- a/test/Factory/NamedOAuth2ServerFactoryTest.php
+++ b/test/Factory/NamedOAuth2ServerFactoryTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\MvcAuth\Factory;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZF\MvcAuth\Factory\NamedOAuth2ServerFactory;
+use ZF\MvcAuth\Factory\OAuth2ServerFactory;
+use Zend\ServiceManager\ServiceManager;
+
+class NamedOAuth2ServerFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->services = $this->setUpConfig(new ServiceManager());
+        $this->factory  = new NamedOAuth2ServerFactory();
+    }
+
+    public function setUpConfig($services)
+    {
+        $services->setService('Config', array(
+            'zf-oauth2' => array(
+                'storage' => 'ZFTest\OAuth2\TestAsset\MockAdapter',
+                'grant_types' => array(
+                    'client_credentials' => true,
+                    'authorization_code' => true,
+                    'password'           => true,
+                    'refresh_token'      => true,
+                    'jwt'                => true,
+                ),
+                'api_problem_error_response' => true,
+            ),
+            'zf-mvc-auth' => array(
+                'authentication' => array(
+                    'adapters' => array(
+                        'test' => array(
+                            'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
+                            'storage' => array(
+                                'storage' => 'ZFTest\OAuth2\TestAsset\MockAdapter',
+                                'route'   => 'test',
+                            ),
+                        ),
+                        'test2' => array(
+                            'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
+                            'storage' => array(
+                                'storage' => 'ZFTest\OAuth2\TestAsset\MockAdapter',
+                                'route'   => 'test2',
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ));
+
+        $oauth2StorageAdapter = $this->getMockBuilder('OAuth2\Storage\Memory')
+            ->disableOriginalConstructor(true)
+            ->getMock();
+
+        $services->setService(
+            'ZFTest\OAuth2\TestAsset\MockAdapter',
+            $oauth2StorageAdapter
+        );
+        return $services;
+    }
+
+    public function testCallingReturnedFactoryMultipleTimesWithNoArgumentReturnsSameServerInstance()
+    {
+        $factory = $this->factory->__invoke($this->services);
+        $server  = $factory();
+        $this->assertSame($server, $factory());
+    }
+
+    public function testCallingReturnedFactoryMultipleTimesWithSameArgumentReturnsSameServerInstance()
+    {
+        $factory = $this->factory->__invoke($this->services);
+        $server  = $factory('test');
+        $this->assertSame($server, $factory('test'));
+    }
+
+    public function testCallingReturnedFactoryMultipleTimesWithDifferentArgumentsReturnsDifferentInstances()
+    {
+        $factory = $this->factory->__invoke($this->services);
+        $server  = $factory('test');
+        $this->assertNotSame($server, $factory());
+        $this->assertNotSame($server, $factory('test2'));
+    }
+
+    public function testCallingReturnedFactoryWithUnrecognizedArgumentReturnsApplicationWideInstance()
+    {
+        $factory = $this->factory->__invoke($this->services);
+        $server  = $factory();
+        $this->assertSame($server, $factory('unknown'));
+    }
+}


### PR DESCRIPTION
One root cause of #70 is that the factories returned by the various
`ZF\OAuth2\Service\OAuth2Server` implementations were not caching the
`OAuth2\Server` instances they generated. This patch ensures that the
zf-mvc-auth implementation does, and is a complement to
zfcampus/zf-oauth2#95.

Additionally, in order to test this, I had to implement a fix for #69:
fixing `ZF\MvcAuth\Factory\OAuth2ServerFactory` to allow named storage
services or an array of named storage services.