### PR TITLE
Change priorities of authentication events

### DIFF
--- a/src/MvcRouteListener.php
+++ b/src/MvcRouteListener.php
@@ -56,8 +56,8 @@ class MvcRouteListener extends AbstractListenerAggregate
      */
     public function attach(EventManagerInterface $events)
     {
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'authentication'), -25);
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'authenticationPost'), -26);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'authentication'), -50);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'authenticationPost'), -51);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'authorization'), -600);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'authorizationPost'), -601);
     }

--- a/test/MvcRouteListenerTest.php
+++ b/test/MvcRouteListenerTest.php
@@ -49,7 +49,7 @@ class MvcRouteListenerTest extends TestCase
     {
         $this->events->attach($this->listener);
         $this->assertListenerAtPriority(
-            -25,
+            -50,
             array($this->listener, 'authentication'),
             $this->events->getListeners('route')
         );
@@ -59,7 +59,7 @@ class MvcRouteListenerTest extends TestCase
     {
         $this->events->attach($this->listener);
         $this->assertListenerAtPriority(
-            -26,
+            -51,
             array($this->listener, 'authenticationPost'),
             $this->events->getListeners('route')
         );


### PR DESCRIPTION
zf-versioning uses priorities -40 and -41 in order to rewrite the matched controller based on versioning information. Since per-API authentication is based on the combination of the API namespace **and** version, authentication listeners _must_ trigger _after_ versioning. As such, this patch moves the priorities for the authentication and authentication.post events to -50 and -51, respectively.