### PR TITLE
[WIP] Composite auth adapter

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -36,6 +36,9 @@ return array(
             'ZF\MvcAuth\Authentication\DefaultAuthenticationPostListener' => 'ZF\MvcAuth\Authentication\DefaultAuthenticationPostListener',
             'ZF\MvcAuth\Authorization\DefaultAuthorizationPostListener' => 'ZF\MvcAuth\Authorization\DefaultAuthorizationPostListener',
         ),
+        'abstract_factories' => array(
+            'ZF\MvcAuth\Factory\AdapterAbstractFactory',
+        ),
     ),
     'zf-mvc-auth' => array(
         'authentication' => array(
@@ -64,7 +67,7 @@ return array(
              * to use to create the Zend\Authentication\Adapter\Http instance.
              *
              * For OAuth2Adapter instances, specify a 'storage' key, with options
-             * to use for matching the adapter and creating an OAuth2 storage 
+             * to use for matching the adapter and creating an OAuth2 storage
              * instance. The array MUST contain a `route' key, with the route
              * at which the specific adapter will match authentication requests.
              * To specify the storage instance, you may use one of two approaches:

--- a/src/Authentication/CompositeAdapter.php
+++ b/src/Authentication/CompositeAdapter.php
@@ -34,7 +34,7 @@ class CompositeAdapter implements AdapterInterface
 
         $types = $adapter->provides();
 
-        foreach($types as $type) {
+        foreach ($types as $type) {
             $this->adapters[$type] = $adapter;
         }
     }
@@ -50,7 +50,7 @@ class CompositeAdapter implements AdapterInterface
     public function removeAdapter($adapterOrType)
     {
         if ($adapterOrType instanceof AdapterInterface) {
-            $adapters = array_filter($this->adapters, function($adapter) use ($adapterOrType) {
+            $adapters = array_filter($this->adapters, function ($adapter) use ($adapterOrType) {
                 return $adapter !== $adapterOrType;
             });
 

--- a/src/Authentication/CompositeAdapter.php
+++ b/src/Authentication/CompositeAdapter.php
@@ -1,8 +1,7 @@
 <?php
 /**
- * @author Stefano Torresi (http://stefanotorresi.it)
- * @license See the file LICENSE.txt for copying permission.
- * ************************************************
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\MvcAuth\Authentication;
@@ -17,16 +16,24 @@ class CompositeAdapter implements AdapterInterface
     /**
      * @var AdapterInterface[]
      */
-    protected $adapters = [];
+    protected $adapters = array();
+
+    /**
+     * @var string
+     */
+    protected $name;
 
     /**
      * @param AdapterInterface[] $adapters
+     * @param string             $name
      */
-    public function __construct(array $adapters = array())
+    public function __construct(array $adapters = array(), $name = null)
     {
         foreach ($adapters as $adapter) {
             $this->addAdapter($adapter);
         }
+
+        $this->name = (string) $name;
     }
 
     /**
@@ -64,7 +71,7 @@ class CompositeAdapter implements AdapterInterface
                 return $adapter !== $adapterOrType;
             });
 
-            $this->adapters = [];
+            $this->adapters = array();
             foreach ($adapters as $adapter) {
                 $this->addAdapter($adapter);
             }
@@ -84,7 +91,13 @@ class CompositeAdapter implements AdapterInterface
      */
     public function provides()
     {
-        return array_keys($this->adapters);
+        $result = array_keys($this->adapters);
+
+        if ($this->name) {
+            $result[] = $this->name;
+        }
+
+        return $result;
     }
 
     /**
@@ -92,7 +105,7 @@ class CompositeAdapter implements AdapterInterface
      */
     public function matches($type)
     {
-        return isset($this->adapters[$type]);
+        return isset($this->adapters[$type]) || ($type && $type === $this->name);
     }
 
     /**

--- a/src/Authentication/CompositeAdapter.php
+++ b/src/Authentication/CompositeAdapter.php
@@ -17,7 +17,17 @@ class CompositeAdapter implements AdapterInterface
     /**
      * @var AdapterInterface[]
      */
-    protected $adapters = array();
+    protected $adapters = [];
+
+    /**
+     * @param AdapterInterface[] $adapters
+     */
+    public function __construct(array $adapters = array())
+    {
+        foreach ($adapters as $adapter) {
+            $this->addAdapter($adapter);
+        }
+    }
 
     /**
      * Adds an adapter
@@ -54,7 +64,7 @@ class CompositeAdapter implements AdapterInterface
                 return $adapter !== $adapterOrType;
             });
 
-            $this->adapters = array();
+            $this->adapters = [];
             foreach ($adapters as $adapter) {
                 $this->addAdapter($adapter);
             }

--- a/src/Authentication/CompositeAdapter.php
+++ b/src/Authentication/CompositeAdapter.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * @author Stefano Torresi (http://stefanotorresi.it)
+ * @license See the file LICENSE.txt for copying permission.
+ * ************************************************
+ */
+
+namespace ZF\MvcAuth\Authentication;
+
+use InvalidArgumentException;
+use Zend\Http\Request;
+use Zend\Http\Response;
+use ZF\MvcAuth\MvcAuthEvent;
+
+class CompositeAdapter implements AdapterInterface
+{
+    /**
+     * @var AdapterInterface[]
+     */
+    protected $adapters = array();
+
+    /**
+     * Adds an adapter
+     *
+     * Subsequently added adapters will take over on previous ones, if they provide the same authentication types
+     *
+     * @param AdapterInterface $adapter
+     */
+    public function addAdapter(AdapterInterface $adapter)
+    {
+        if (in_array($adapter, $this->adapters, true)) {
+            return;
+        }
+
+        $types = $adapter->provides();
+
+        foreach($types as $type) {
+            $this->adapters[$type] = $adapter;
+        }
+    }
+
+    /**
+     * Removes an adapter
+     *
+     * If an AdapterInterface instance is passed and that adapter superseded a previously added one,
+     * the remaining ones will be re-added to take control back on their provided type
+     *
+     * @param AdapterInterface|string
+     */
+    public function removeAdapter($adapterOrType)
+    {
+        if ($adapterOrType instanceof AdapterInterface) {
+            $adapters = array_filter($this->adapters, function($adapter) use ($adapterOrType) {
+                return $adapter !== $adapterOrType;
+            });
+
+            $this->adapters = array();
+            foreach ($adapters as $adapter) {
+                $this->addAdapter($adapter);
+            }
+
+            return;
+        }
+
+        if (! is_string($adapterOrType)) {
+            throw new InvalidArgumentException('Expected AdapterInterface or string');
+        }
+
+        unset($this->adapters[$adapterOrType]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provides()
+    {
+        return array_keys($this->adapters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function matches($type)
+    {
+        return isset($this->adapters[$type]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeFromRequest(Request $request)
+    {
+        foreach ($this->adapters as $adapter) {
+            $type = $adapter->getTypeFromRequest($request);
+            if (false !== $type && $adapter === $this->adapters[$type]) {
+                return $type;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * If one of the adapters returns a Response,
+     * the cycle will be interrupted and all remaining pre flight checks will not be executed
+     *
+     * {@inheritdoc}
+     */
+    public function preAuth(Request $request, Response $response)
+    {
+        foreach ($this->adapters as $adapter) {
+            $result = $adapter->preAuth($request, $response);
+            if ($result instanceof Response) {
+                return $result;
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function authenticate(Request $request, Response $response, MvcAuthEvent $mvcAuthEvent)
+    {
+        $type = $this->getTypeFromRequest($request);
+
+        if (! $type) {
+            return false;
+        }
+
+        $adapter = $this->adapters[$type];
+
+        return $adapter->authenticate($request, $response, $mvcAuthEvent);
+    }
+}

--- a/src/Factory/AdapterAbstractFactory.php
+++ b/src/Factory/AdapterAbstractFactory.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\MvcAuth\Factory;
+
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\MvcAuth\Authentication\AdapterInterface;
+
+class AdapterAbstractFactory implements AbstractFactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        $config = $serviceLocator->get('config');
+
+        $hasMatches = preg_match('/^zf-mvc-auth-authentication-adapters-(?P<name>\w+)$/', $requestedName, $matches);
+
+        if (! $hasMatches) {
+            return false;
+        }
+
+        $adapterName = $matches['name'];
+
+        if (! isset($config['zf-mvc-auth']['authentication']['adapters'][$adapterName]['adapter'])) {
+            return false;
+        }
+
+        $adapter = $config['zf-mvc-auth']['authentication']['adapters'][$adapterName]['adapter'];
+
+        if (! is_string($adapter)) {
+            return false;
+        }
+
+        if ($serviceLocator->has($adapter) && ! $serviceLocator->get($adapter) instanceof AdapterInterface) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        $adapterName = substr($requestedName, strrpos($requestedName, '-') + 1);
+        $config      = $serviceLocator->get('config');
+        $adapterSpec = $config['zf-mvc-auth']['authentication']['adapters'][$adapterName];
+
+        if (! isset($adapterSpec['adapter']) || ! is_string($adapterSpec['adapter'])) {
+            return false;
+        }
+
+        switch ($adapterSpec['adapter']) {
+            case 'ZF\MvcAuth\Authentication\HttpAdapter':
+                $adapter = AuthenticationHttpAdapterFactory::factory($adapterName, $adapterSpec, $serviceLocator);
+                break;
+            case 'ZF\MvcAuth\Authentication\OAuth2Adapter':
+                $adapter = AuthenticationOAuth2AdapterFactory::factory($adapterName, $adapterSpec, $serviceLocator);
+                break;
+            case 'ZF\MvcAuth\Authentication\CompositeAdapter':
+                $adapter = AuthenticationCompositeAdapterFactory::factory($adapterName, $adapterSpec, $serviceLocator);
+                break;
+            default:
+                $adapter = $serviceLocator->get($adapterSpec['adapter']);
+                break;
+        }
+
+        return $adapter;
+    }
+}

--- a/src/Factory/AuthenticationAdapterDelegatorFactory.php
+++ b/src/Factory/AuthenticationAdapterDelegatorFactory.php
@@ -6,6 +6,7 @@
 namespace ZF\MvcAuth\Factory;
 
 use Zend\ServiceManager\DelegatorFactoryInterface;
+use Zend\ServiceManager\Exception\ExceptionInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class AuthenticationAdapterDelegatorFactory implements DelegatorFactoryInterface
@@ -25,26 +26,13 @@ class AuthenticationAdapterDelegatorFactory implements DelegatorFactoryInterface
             return $listener;
         }
 
-        foreach ($config['zf-mvc-auth']['authentication']['adapters'] as $type => $data) {
-            if (! isset($data['adapter']) || ! is_string($data['adapter'])) {
+        foreach ($config['zf-mvc-auth']['authentication']['adapters'] as $name => $spec) {
+            try {
+                $adapter = $services->get('zf-mvc-auth-authentication-adapters-' . $name);
+            } catch (ExceptionInterface $e) {
                 continue;
             }
-
-            switch ($data['adapter']) {
-                case 'ZF\MvcAuth\Authentication\HttpAdapter':
-                    $adapter = AuthenticationHttpAdapterFactory::factory($type, $data, $services);
-                    break;
-                case 'ZF\MvcAuth\Authentication\OAuth2Adapter':
-                    $adapter = AuthenticationOAuth2AdapterFactory::factory($type, $data, $services);
-                    break;
-                default:
-                    $adapter = false;
-                    break;
-            }
-
-            if ($adapter) {
-                $listener->attach($adapter);
-            }
+            $listener->attach($adapter);
         }
 
         return $listener;

--- a/src/Factory/AuthenticationCompositeAdapterFactory.php
+++ b/src/Factory/AuthenticationCompositeAdapterFactory.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\MvcAuth\Factory;
+
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\MvcAuth\Authentication\CompositeAdapter;
+
+final class AuthenticationCompositeAdapterFactory
+{
+    /**
+     * Intentionally empty and private to prevent instantiation
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Create and return an CompositeAdapter instance.
+     *
+     * @param string|array $type
+     * @param array $config
+     * @param ServiceLocatorInterface $services
+     * @return CompositeAdapter
+     * @throws ServiceNotCreatedException when missing details necessary to
+     *     create instance and/or dependencies.
+     */
+    public static function factory($type, array $config, ServiceLocatorInterface $services)
+    {
+        if (! isset($config['adapters']) || ! is_array($config['adapters'])) {
+            throw new ServiceNotCreatedException('No adapters configured for CompositeAdapters');
+        }
+
+        $adapters = array();
+
+        foreach ($config['adapters'] as $name) {
+            $adapters[] = $services->get('zf-mvc-auth-authentication-adapters-' . $name);
+        }
+
+        return new CompositeAdapter($adapters, $type);
+    }
+}

--- a/test/Authentication/CompositeAdapterTest.php
+++ b/test/Authentication/CompositeAdapterTest.php
@@ -1,0 +1,359 @@
+<?php
+/**
+ * @author Stefano Torresi (http://stefanotorresi.it)
+ * @license See the file LICENSE.txt for copying permission.
+ * ************************************************
+ */
+
+namespace ZFTest\MvcAuth\Authentication;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Http\Request;
+use Zend\Http\Response;
+use ZF\MvcAuth\Authentication\CompositeAdapter;
+
+class CompositeAdapterTest extends TestCase
+{
+    /**
+     * @var CompositeAdapter
+     */
+    protected $adapter;
+
+    public function setUp()
+    {
+        $this->adapter = new CompositeAdapter();
+    }
+
+    public function testCanAddAdapter()
+    {
+        $adapterMock = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $mockProvides = array('foo', 'bar');
+        $adapterMock
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mockProvides))
+        ;
+        $this->adapter->addAdapter($adapterMock);
+
+        $this->assertEquals($mockProvides, $this->adapter->provides());
+        $this->assertTrue($this->adapter->matches('foo'));
+        $this->assertTrue($this->adapter->matches('bar'));
+    }
+
+    public function testAddAdapterIsIdemPotent()
+    {
+        $adapterMock = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $mockProvides = array('foo', 'bar');
+        $adapterMock
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mockProvides))
+        ;
+        $this->adapter->addAdapter($adapterMock);
+
+        $oldAdapter = serialize($this->adapter);
+
+        $this->adapter->addAdapter($adapterMock);
+
+        $newAdapter = serialize($this->adapter);
+
+        $this->assertSame($oldAdapter, $newAdapter);
+    }
+
+    public function testCanAddMultipleAdapters()
+    {
+        $adapterMock1 = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $adapterMock2 = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $mock1Provides = array('foo', 'bar');
+        $mock2Provides = array('bar', 'baz');
+        $adapterMock1
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mock1Provides))
+        ;
+        $adapterMock2
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mock2Provides))
+        ;
+
+        $this->adapter->addAdapter($adapterMock1);
+        $this->adapter->addAdapter($adapterMock2);
+
+        $this->assertEquals(
+            array_values(array_unique(array_merge($mock1Provides, $mock2Provides))),
+            $this->adapter->provides()
+        );
+    }
+
+    public function testCanRemoveAdapter()
+    {
+        $adapterMock = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $mockProvides = array('foo', 'bar');
+        $adapterMock
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mockProvides))
+        ;
+        $this->adapter->addAdapter($adapterMock);
+        $this->adapter->removeAdapter($adapterMock);
+
+        $this->assertEmpty($this->adapter->provides());
+    }
+
+    public function testCanRemoveAdapterByType()
+    {
+        $adapterMock1 = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $adapterMock2 = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $mock1Provides = array('foo', 'bar');
+        $mock2Provides = array('bar', 'baz');
+        $adapterMock1
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mock1Provides))
+        ;
+        $adapterMock2
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mock2Provides))
+        ;
+
+        $this->adapter->addAdapter($adapterMock1);
+        $this->adapter->addAdapter($adapterMock2);
+
+        $this->adapter->removeAdapter('baz');
+
+        $this->assertEquals($mock1Provides, $this->adapter->provides());
+    }
+
+    /**
+     * @param mixed $invalidValue
+     *
+     * @dataProvider invalidRemoveValues
+     */
+    public function testRemoveAdapterWithInvalidValuesThrows($invalidValue)
+    {
+        $this->setExpectedException('InvalidArgumentException');
+
+        $this->adapter->removeAdapter($invalidValue);
+    }
+
+    public function invalidRemoveValues()
+    {
+        return array(
+            array( 0 ),
+            array( new \stdClass() ),
+            array( true ),
+            array( array() ),
+        );
+    }
+
+    public function testPreviouslyAddedAdaptersCanHandleTypesSupersededByRemovedOnes()
+    {
+        $adapterMock1 = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $adapterMock2 = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $mock1Provides = array('foo', 'bar');
+        $mock2Provides = array('bar', 'baz');
+        $adapterMock1
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mock1Provides))
+        ;
+        $adapterMock2
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mock2Provides))
+        ;
+
+        $this->adapter->addAdapter($adapterMock1);
+        $this->adapter->addAdapter($adapterMock2);
+
+        $this->adapter->removeAdapter($adapterMock2);
+
+        $this->assertEquals($mock1Provides, $this->adapter->provides());
+    }
+
+    public function testCanGetTypeFromRequest()
+    {
+        $request      = new Request();
+        $adapterMock  = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $mockProvides = array('foo', 'bar');
+        $adapterMock
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mockProvides))
+        ;
+        $adapterMock
+            ->expects($this->any())
+            ->method('getTypeFromRequest')
+            ->with($request)
+            ->will($this->returnValue('foo'))
+        ;
+
+        $this->adapter->addAdapter($adapterMock);
+
+        $this->assertEquals('foo', $this->adapter->getTypeFromRequest($request));
+    }
+
+    public function testGetTypeFromRequestCanReturnFalse()
+    {
+        $request      = new Request();
+        $adapterMock  = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $mockProvides = array('foo', 'bar');
+        $adapterMock
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mockProvides))
+        ;
+        $adapterMock
+            ->expects($this->any())
+            ->method('getTypeFromRequest')
+            ->with($request)
+            ->will($this->returnValue(false))
+        ;
+
+        $this->adapter->addAdapter($adapterMock);
+
+        $this->assertFalse($this->adapter->getTypeFromRequest($request));
+    }
+
+    public function testDelegatesAuthentication()
+    {
+        $request      = new Request();
+        $response     = new Response();
+        $event        = $this->getMockBuilder('\ZF\MvcAuth\MvcAuthEvent')->disableOriginalConstructor()->getMock();
+        $adapterMock1 = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $adapterMock2 = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $mock1Provides = array('foo', 'bar');
+        $mock2Provides = array('bar', 'baz');
+        $adapterMock1
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mock1Provides))
+        ;
+        $adapterMock1
+            ->expects($this->any())
+            ->method('getTypeFromRequest')
+            ->with($request)
+            ->will($this->returnValue('bar'))
+        ;
+        $adapterMock1
+            ->expects($this->never()) // we assert that the first adapter is superseded by the second one
+            ->method('authenticate')
+        ;
+        $adapterMock2
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mock2Provides))
+        ;
+        $adapterMock2
+            ->expects($this->any())
+            ->method('getTypeFromRequest')
+            ->with($request)
+            ->will($this->returnValue('bar'))
+        ;
+        $adapterMock2
+            ->expects($this->atLeastOnce())
+            ->method('authenticate')
+            ->with($request, $response, $event)
+            ->will($this->returnValue(true))
+        ;
+
+        $this->adapter->addAdapter($adapterMock1);
+        $this->adapter->addAdapter($adapterMock2);
+
+        $this->assertTrue($this->adapter->authenticate($request, $response, $event));
+    }
+
+    public function testAuthenticationCanReturnFalse()
+    {
+        $request      = new Request();
+        $response     = new Response();
+        $event        = $this->getMockBuilder('\ZF\MvcAuth\MvcAuthEvent')->disableOriginalConstructor()->getMock();
+        $adapterMock  = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $mockProvides = array('foo', 'bar');
+        $adapterMock
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mockProvides))
+        ;
+        $adapterMock
+            ->expects($this->any())
+            ->method('getTypeFromRequest')
+            ->with($request)
+            ->will($this->returnValue(false))
+        ;
+
+        $this->adapter->addAdapter($adapterMock);
+
+        $this->assertFalse($this->adapter->authenticate($request, $response, $event));
+    }
+
+    public function testDelegatesPreAuth()
+    {
+        $request      = new Request();
+        $response     = new Response();
+        $adapterMock1 = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $adapterMock2 = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $mock1Provides = array('foo', 'bar');
+        $mock2Provides = array('bar', 'baz');
+        $adapterMock1
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mock1Provides))
+        ;
+        $adapterMock1
+            ->expects($this->atLeastOnce())
+            ->method('preAuth')
+            ->with($request, $response)
+        ;
+        $adapterMock2
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mock2Provides))
+        ;
+        $adapterMock2
+            ->expects($this->atLeastOnce())
+            ->method('preAuth')
+            ->with($request, $response)
+        ;
+
+        $this->adapter->addAdapter($adapterMock1);
+        $this->adapter->addAdapter($adapterMock2);
+        $this->adapter->preAuth($request, $response);
+    }
+
+    public function testPreAuthShortCircuitsWhenAnAdapterReturnsAResponse()
+    {
+        $request      = new Request();
+        $response     = new Response();
+        $adapterMock1 = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $adapterMock2 = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $mock1Provides = array('foo', 'bar');
+        $mock2Provides = array('bar', 'baz');
+        $adapterMock1
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mock1Provides))
+        ;
+        $adapterMock1
+            ->expects($this->atLeastOnce())
+            ->method('preAuth')
+            ->with($request, $response)
+            ->will($this->returnValue($response))
+        ;
+        $adapterMock2
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mock2Provides))
+        ;
+        $adapterMock2
+            ->expects($this->never())
+            ->method('preAuth')
+        ;
+
+        $this->adapter->addAdapter($adapterMock1);
+        $this->adapter->addAdapter($adapterMock2);
+        $this->assertSame($response, $this->adapter->preAuth($request, $response));
+    }
+}

--- a/test/Authentication/CompositeAdapterTest.php
+++ b/test/Authentication/CompositeAdapterTest.php
@@ -86,6 +86,31 @@ class CompositeAdapterTest extends TestCase
         );
     }
 
+    public function testCanAddAdaptersViaConstructor()
+    {
+        $adapterMock1 = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $adapterMock2 = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $mock1Provides = array('foo', 'bar');
+        $mock2Provides = array('bar', 'baz');
+        $adapterMock1
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mock1Provides))
+        ;
+        $adapterMock2
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mock2Provides))
+        ;
+
+        $adapter = new CompositeAdapter([ $adapterMock1, $adapterMock2 ]);
+
+        $this->assertEquals(
+            array_values(array_unique(array_merge($mock1Provides, $mock2Provides))),
+            $adapter->provides()
+        );
+    }
+
     public function testCanRemoveAdapter()
     {
         $adapterMock = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');

--- a/test/Authentication/CompositeAdapterTest.php
+++ b/test/Authentication/CompositeAdapterTest.php
@@ -1,8 +1,7 @@
 <?php
 /**
- * @author Stefano Torresi (http://stefanotorresi.it)
- * @license See the file LICENSE.txt for copying permission.
- * ************************************************
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZFTest\MvcAuth\Authentication;
@@ -103,7 +102,7 @@ class CompositeAdapterTest extends TestCase
             ->will($this->returnValue($mock2Provides))
         ;
 
-        $adapter = new CompositeAdapter([ $adapterMock1, $adapterMock2 ]);
+        $adapter = new CompositeAdapter(array($adapterMock1, $adapterMock2));
 
         $this->assertEquals(
             array_values(array_unique(array_merge($mock1Provides, $mock2Provides))),
@@ -380,5 +379,26 @@ class CompositeAdapterTest extends TestCase
         $this->adapter->addAdapter($adapterMock1);
         $this->adapter->addAdapter($adapterMock2);
         $this->assertSame($response, $this->adapter->preAuth($request, $response));
+    }
+
+    public function testCanBeInitializedWithName()
+    {
+
+        $adapterMock = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $mockProvides = array('foo', 'bar');
+        $adapterMock
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue($mockProvides))
+        ;
+
+        $adapter = new CompositeAdapter(array($adapterMock), 'baz');
+
+        $this->assertContains('bar', $adapter->provides());
+        $this->assertContains('foo', $adapter->provides());
+        $this->assertContains('baz', $adapter->provides());
+        $this->assertTrue($adapter->matches('foo'));
+        $this->assertTrue($adapter->matches('bar'));
+        $this->assertTrue($adapter->matches('baz'));
     }
 }

--- a/test/Factory/AdapterAbstractFactoryTest.php
+++ b/test/Factory/AdapterAbstractFactoryTest.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\MvcAuth\Factory;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\ServiceManager\ServiceManager;
+use ZF\MvcAuth\Factory\AdapterAbstractFactory;
+
+class AdapterAbstractFactoryTest extends TestCase
+{
+    /**
+     * @var AdapterAbstractFactory
+     */
+    protected $factory;
+
+    /**
+     * @var ServiceManager
+     */
+    protected $serviceManager;
+
+    public function setUp()
+    {
+        $this->factory        = new AdapterAbstractFactory();
+        $this->serviceManager = new ServiceManager();
+
+        $config = array(
+            'zf-oauth2' => array(
+                'grant_types' => array(
+                    'client_credentials' => true,
+                    'authorization_code' => true,
+                    'password'           => true,
+                    'refresh_token'      => true,
+                    'jwt'                => true,
+                ),
+                'api_problem_error_response' => true,
+            ),
+            'zf-mvc-auth' => array(
+                'authentication' => array(
+                    'adapters' => array(
+                        'foo' => array(
+                            'adapter' => 'ZF\MvcAuth\Authentication\HttpAdapter',
+                            'options' => array(
+                                'accept_schemes' => array('basic'),
+                                'realm' => 'api',
+                                'htpasswd' => __DIR__ . '/../TestAsset/htpasswd',
+                            ),
+                        ),
+                        'bar' => array(
+                            'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
+                            'storage' => array(
+                                'adapter' => 'pdo',
+                                'dsn' => 'sqlite::memory:',
+                            ),
+                        ),
+                        'baz' => array(
+                            'adapter' => 'CUSTOM',
+                        ),
+                        'bat' => array(
+                            // intentionally empty
+                        ),
+                        'batman' => array(
+                            'adapter' => 'ZF\MvcAuth\Authentication\CompositeAdapter',
+                            'adapters' => array('foo', 'bar'),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->serviceManager->setService('config', $config);
+        $this->serviceManager->setService('authentication', $this->getMock('Zend\Authentication\AuthenticationService'));
+        $this->serviceManager->setService('CUSTOM', $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface'));
+        $this->serviceManager->addAbstractFactory($this->factory);
+    }
+
+    public function testCanCreateServiceWithName()
+    {
+        $this->assertTrue($this->factory->canCreateServiceWithName(
+            $this->serviceManager,
+            '',
+            'zf-mvc-auth-authentication-adapters-foo'
+        ));
+
+        $this->assertTrue($this->factory->canCreateServiceWithName(
+            $this->serviceManager,
+            '',
+            'zf-mvc-auth-authentication-adapters-bar'
+        ));
+
+        $this->assertTrue($this->factory->canCreateServiceWithName(
+            $this->serviceManager,
+            '',
+            'zf-mvc-auth-authentication-adapters-baz'
+        ));
+
+        $this->assertFalse($this->factory->canCreateServiceWithName(
+            $this->serviceManager,
+            '',
+            'zf-mvc-auth-authentication-adapters-bat'
+        ));
+
+        $this->assertFalse($this->factory->canCreateServiceWithName(
+            $this->serviceManager,
+            '',
+            'foo-bar-baz'
+        ));
+
+        $this->assertTrue($this->factory->canCreateServiceWithName(
+            $this->serviceManager,
+            '',
+            'zf-mvc-auth-authentication-adapters-batman'
+        ));
+    }
+
+    public function testCreateServiceWithName()
+    {
+        $fooAdapter = $this->factory->createServiceWithName(
+            $this->serviceManager,
+            '',
+            'zf-mvc-auth-authentication-adapters-foo'
+        );
+
+        $this->assertInstanceOf('\ZF\MvcAuth\Authentication\HttpAdapter', $fooAdapter);
+
+        $barAdapter = $this->factory->createServiceWithName(
+            $this->serviceManager,
+            '',
+            'zf-mvc-auth-authentication-adapters-bar'
+        );
+
+        $this->assertInstanceOf('ZF\MvcAuth\Authentication\OAuth2Adapter', $barAdapter);
+
+        $batmanAdapter = $this->factory->createServiceWithName(
+            $this->serviceManager,
+            '',
+            'zf-mvc-auth-authentication-adapters-batman'
+        );
+
+        $this->assertInstanceOf('ZF\MvcAuth\Authentication\CompositeAdapter', $batmanAdapter);
+
+        $bazAdapter = $this->factory->createServiceWithName(
+            $this->serviceManager,
+            '',
+            'zf-mvc-auth-authentication-adapters-baz'
+        );
+
+        $this->assertSame($bazAdapter, $this->serviceManager->get('CUSTOM'));
+
+        $this->assertFalse($this->factory->createServiceWithName(
+            $this->serviceManager,
+            '',
+            'zf-mvc-auth-authentication-adapters-bat'
+        ));
+    }
+}

--- a/test/Factory/AdapterAbstractFactoryTest.php
+++ b/test/Factory/AdapterAbstractFactoryTest.php
@@ -72,7 +72,10 @@ class AdapterAbstractFactoryTest extends TestCase
         );
 
         $this->serviceManager->setService('config', $config);
-        $this->serviceManager->setService('authentication', $this->getMock('Zend\Authentication\AuthenticationService'));
+        $this->serviceManager->setService(
+            'authentication',
+            $this->getMock('Zend\Authentication\AuthenticationService')
+        );
         $this->serviceManager->setService('CUSTOM', $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface'));
         $this->serviceManager->addAbstractFactory($this->factory);
     }

--- a/test/Factory/AuthenticationAdapterDelegatorFactoryTest.php
+++ b/test/Factory/AuthenticationAdapterDelegatorFactoryTest.php
@@ -9,6 +9,7 @@ namespace ZFTest\MvcAuth\Factory;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\ServiceManager\ServiceManager;
 use ZF\MvcAuth\Authentication\DefaultAuthenticationListener;
+use ZF\MvcAuth\Factory\AdapterAbstractFactory;
 use ZF\MvcAuth\Factory\AuthenticationAdapterDelegatorFactory;
 
 class AuthenticationAdapterDelegatorFactoryTest extends TestCase
@@ -79,12 +80,17 @@ class AuthenticationAdapterDelegatorFactoryTest extends TestCase
                         'bat' => array(
                             // intentionally empty
                         ),
+                        'batman' => array(
+                            'adapter' => 'ZF\MvcAuth\Authentication\CompositeAdapter',
+                            'adapters' => array('foo', 'bar'),
+                        ),
                     ),
                 ),
             ),
         );
         $this->services->setService('Config', $config);
         $this->services->setService('authentication', $this->getMock('Zend\Authentication\AuthenticationService'));
+        $this->services->addAbstractFactory(new AdapterAbstractFactory());
 
         $listener = $this->factory->createDelegatorWithName(
             $this->services,
@@ -93,9 +99,9 @@ class AuthenticationAdapterDelegatorFactoryTest extends TestCase
             $this->callback
         );
         $this->assertSame($this->listener, $listener);
-        $this->assertEquals(array(
-            'foo-basic',
-            'bar'
-        ), $listener->getAuthenticationTypes());
+        $this->assertCount(3, $listener->getAuthenticationTypes());
+        $this->assertContains('foo-basic', $listener->getAuthenticationTypes());
+        $this->assertContains('bar', $listener->getAuthenticationTypes());
+        $this->assertContains('batman', $listener->getAuthenticationTypes());
     }
 }

--- a/test/Factory/AuthenticationCompositeAdapterFactoryTest.php
+++ b/test/Factory/AuthenticationCompositeAdapterFactoryTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\MvcAuth\Factory;
+
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\MvcAuth\Factory\AuthenticationCompositeAdapterFactory;
+
+class AuthenticationCompositeAdapterFactoryTest extends TestCase
+{
+    /**
+     * @var ServiceLocatorInterface|MockObject
+     */
+    protected $serviceLocator;
+
+    public function setUp()
+    {
+        $this->serviceLocator = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+    }
+
+    public function invalidConfiguration()
+    {
+        return array(
+            'empty'  => array(array()),
+            'null'   => array(array('adapters' => null)),
+            'bool'   => array(array('adapters' => true)),
+            'int'    => array(array('adapters' => 1)),
+            'float'  => array(array('adapters' => 1.1)),
+            'string' => array(array('adapters' => 'options')),
+            'object' => array(array('adapters' => (object) array('storage'))),
+        );
+    }
+
+    /**
+     * @dataProvider invalidConfiguration
+     */
+    public function testRaisesExceptionForMissingOrInvalidStorage(array $config)
+    {
+        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotCreatedException', 'No adapters configured');
+        AuthenticationCompositeAdapterFactory::factory('foo', $config, $this->serviceLocator);
+    }
+
+    public function testCreatesInstanceFromValidConfiguration()
+    {
+        $config = array(
+            'adapters' => array('foo', 'bar'),
+        );
+
+        $fooAdapter = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $barAdapter = $this->getMock('ZF\MvcAuth\Authentication\AdapterInterface');
+        $fooAdapter
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue(array('foo')))
+        ;
+        $barAdapter
+            ->expects($this->any())
+            ->method('provides')
+            ->will($this->returnValue(array('bar')))
+        ;
+
+        $this->serviceLocator->expects($this->any())
+            ->method('get')
+            ->with($this->logicalOr(
+                'zf-mvc-auth-authentication-adapters-foo',
+                'zf-mvc-auth-authentication-adapters-bar'
+            ))
+            ->will($this->returnCallback(function($name) use ($fooAdapter, $barAdapter) {
+                switch($name) {
+                    case 'zf-mvc-auth-authentication-adapters-foo' :
+                        return $fooAdapter;
+                    case 'zf-mvc-auth-authentication-adapters-bar' :
+                        return $barAdapter;
+                }
+            }));
+
+        $adapter = AuthenticationCompositeAdapterFactory::factory('foobar', $config, $this->serviceLocator);
+        $this->assertInstanceOf('ZF\MvcAuth\Authentication\CompositeAdapter', $adapter);
+        $this->assertEquals(array('foo', 'bar', 'foobar'), $adapter->provides());
+    }
+}

--- a/test/Factory/AuthenticationCompositeAdapterFactoryTest.php
+++ b/test/Factory/AuthenticationCompositeAdapterFactoryTest.php
@@ -41,7 +41,10 @@ class AuthenticationCompositeAdapterFactoryTest extends TestCase
      */
     public function testRaisesExceptionForMissingOrInvalidStorage(array $config)
     {
-        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotCreatedException', 'No adapters configured');
+        $this->setExpectedException(
+            'Zend\ServiceManager\Exception\ServiceNotCreatedException',
+            'No adapters configured'
+        );
         AuthenticationCompositeAdapterFactory::factory('foo', $config, $this->serviceLocator);
     }
 
@@ -70,11 +73,11 @@ class AuthenticationCompositeAdapterFactoryTest extends TestCase
                 'zf-mvc-auth-authentication-adapters-foo',
                 'zf-mvc-auth-authentication-adapters-bar'
             ))
-            ->will($this->returnCallback(function($name) use ($fooAdapter, $barAdapter) {
+            ->will($this->returnCallback(function ($name) use ($fooAdapter, $barAdapter) {
                 switch($name) {
-                    case 'zf-mvc-auth-authentication-adapters-foo' :
+                    case 'zf-mvc-auth-authentication-adapters-foo':
                         return $fooAdapter;
-                    case 'zf-mvc-auth-authentication-adapters-bar' :
+                    case 'zf-mvc-auth-authentication-adapters-bar':
                         return $barAdapter;
                 }
             }));


### PR DESCRIPTION
As originally proposed in #65

This PR adds the possibility to use multiple authentication adapters under the same `type`.

It also introduces an `AdapterAbstractFactory` that allows to retrieve each adapter from the `ServiceManager` under the naming convention `zf-mvc-auth-authentication-adapters-{type}`.
This enables a new method to register custom adapters: using a service name the `adapter` key of a named adapter configuration.

TO-DO:
- [ ] Provide a way to use the composite adapter as a default one for all APIs
- [ ] Integration Tests
- [ ] Update the README
