### PR TITLE
Merging config so 'zf-oauth2' config overrides are respected

### DIFF
--- a/src/Factory/OAuth2ServerFactory.php
+++ b/src/Factory/OAuth2ServerFactory.php
@@ -42,7 +42,7 @@ final class OAuth2ServerFactory
         $options      = self::marshalOptions($oauth2Config);
 
         $oauth2Server = new OAuth2Server(
-            self::createStorage($config, $services),
+            self::createStorage(array_merge($oauth2Config, $config), $services),
             $options
         );
 


### PR DESCRIPTION
Hi @weierophinney, hope all is well at your end.

I was overriding the 'user_table' value of the bshaffer oauth lib and was seeing unexpected 401 status code responses.  

On further investigation I noticed that the config array with the 'storage_settings' key wasn't being passed to the create storage method and the default 'oauth_users' table was being used instead.

After merging the config my overrides were respected and the tests continued to pass.