### PR TITLE
[proposal] Flexible createStorageFromAdapter

### DIFF
--- a/src/Factory/OAuth2ServerFactory.php
+++ b/src/Factory/OAuth2ServerFactory.php
@@ -88,7 +88,8 @@ final class OAuth2ServerFactory
             case 'mongo':
                 return self::createMongoAdapter($config, $services);
             default:
-                throw new ServiceNotCreatedException('Invalid storage adapter type for OAuth2');
+                $callback = $services->get($adapter);
+                return $callback($config, $services);
         }
     }
 


### PR DESCRIPTION
zf-mvc-auth and zf-oauth2 each have specific code for specific adapters for OAuth2 and they do not allow code which is not for those adapters to hook in properly to support multiple OAuth2 connections of the same adapter.  This is demonstrated by config::zf-oauth2 configuring in a global space.

I propose zf-oauth2 be reduced to a controller and user id provider and all adapter code be moved into individual adapters named zf-oauth2-[adapter].  These adapter repos will support the combined logic of zf-mvc-auth and zf-oauth2 adapters and factories.  zf-oauth2 will no longer have local configuration

Configuration of zf-oauth2-[adapter]s will be handled through zf-mvc-auth like this:
```
    'zf-mvc-auth' => array(
        'authentication' => array(
            'adapters' => array(
                'named_adapter' => array(
                    'adapter' => 'ZF\\MvcAuth\\Authentication\\OAuth2Adapter',
                    'storage' => array(
                        'adapter' => 'ZF\OAuth2\Pdo\Adapter',
                        'dsn' => 'mysql:dbname=database;host=localhost',
                        'route' => '/oauth',
                        'username' => 'db',
                        'password' => '',
                    ),
                ),
            ),
        ),
    ),
```

This would be handled in `src/Factory/OAuth2ServerFactory.php` at `createStorageFromAdapter`
```
private static function createStorageFromAdapter($adapter, array $config, ServiceLocatorInterface $services)
{
    $callback = $services->get($adapter);
    return $callback($config, $services);
}
```