### PR TITLE
Reply with 401 to requests with expired tokens

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "zfcampus/zf-oauth2": "^1.1.1"
     },
     "require-dev": {
-        "phpunit/PHPUnit": "3.7.*",
+        "phpunit/phpunit": "~4.7",
         "squizlabs/php_codesniffer": "^2.3",
         "zendframework/zend-loader": ">=2.3,<2.5",
         "zendframework/zend-session": ">=2.3,<2.5"

--- a/src/Authentication/DefaultAuthenticationListener.php
+++ b/src/Authentication/DefaultAuthenticationListener.php
@@ -185,6 +185,11 @@ class DefaultAuthenticationListener
         // Authenticate against first matching adapter
         $identity = $this->authenticate($type, $request, $response, $mvcAuthEvent);
 
+        // If the adapter returns a response instance, return it directly.
+        if ($identity instanceof HttpResponse) {
+            return $identity;
+        }
+
         // If no identity returned, create a guest identity
         if (! $identity instanceof Identity\IdentityInterface) {
             $identity = new Identity\GuestIdentity();

--- a/test/Authentication/DefaultAuthenticationListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationListenerTest.php
@@ -798,7 +798,13 @@ class DefaultAuthenticationListenerTest extends TestCase
             ->method('verifyResourceRequest')
             ->with($this->callback(function (OAuth2Request $request) {
                 return $request->headers('Authorization') === 'Bearer TOKEN';
-            }));
+            }))
+            ->willReturn(true);
+
+        $server->expects($this->atLeastOnce())
+            ->method('getAccessTokenData')
+            ->with($this->anything())
+            ->willReturn(array('user_id' => 'TOKEN'));
 
         $this->listener->attach(new OAuth2Adapter($server));
         $this->listener->__invoke($this->mvcAuthEvent);

--- a/test/Authentication/OAuth2AdapterTest.php
+++ b/test/Authentication/OAuth2AdapterTest.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\MvcAuth\Authentication;
+
+use ArrayIterator;
+use OAuth2\Request as OAuth2Request;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Http\PhpEnvironment\Request as HttpRequest;
+use Zend\Http\Response as HttpResponse;
+use ZF\MvcAuth\Authentication\OAuth2Adapter;
+
+class OAuth2AdapterTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->oauthServer = $this->getMock('OAuth2\Server');
+        $this->adapter = new OAuth2Adapter($this->oauthServer);
+    }
+
+    /**
+     * @group 83
+     */
+    public function testReturns401ResponseWhenErrorOccursDuringValidation()
+    {
+        $oauth2Response = $this->getMockBuilder('OAuth2\Response')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $oauth2Response
+            ->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(401);
+        $oauth2Response
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with($this->equalTo('error'))
+            ->willReturn('invalid');
+        $oauth2Response
+            ->expects($this->once())
+            ->method('getHttpHeaders')
+            ->willReturn(array());
+
+        $this->oauthServer
+            ->expects($this->once())
+            ->method('verifyResourceRequest')
+            ->with($this->callback(function ($subject) {
+                return ($subject instanceof OAuth2Request);
+            }))
+            ->willReturn(false);
+
+        $this->oauthServer
+            ->expects($this->once())
+            ->method('getResponse')
+            ->willReturn($oauth2Response);
+
+        $mvcAuthEvent = $this->getMockBuilder('ZF\MvcAuth\MvcAuthEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $result = $this->adapter->authenticate(new HttpRequest, new HttpResponse, $mvcAuthEvent);
+        $this->assertInstanceOf('Zend\Http\Response', $result);
+        $this->assertEquals(401, $result->getStatusCode());
+    }
+
+    /**
+     * @group 83
+     */
+    public function testReturns403ResponseWhenInvalidScopeDetected()
+    {
+        $oauth2Response = $this->getMockBuilder('OAuth2\Response')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $oauth2Response
+            ->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(403);
+        $oauth2Response
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with($this->equalTo('error'))
+            ->willReturn('invalid');
+        $oauth2Response
+            ->expects($this->once())
+            ->method('getHttpHeaders')
+            ->willReturn(array());
+
+        $this->oauthServer
+            ->expects($this->once())
+            ->method('verifyResourceRequest')
+            ->with($this->callback(function ($subject) {
+                return ($subject instanceof OAuth2Request);
+            }))
+            ->willReturn(false);
+
+        $this->oauthServer
+            ->expects($this->once())
+            ->method('getResponse')
+            ->willReturn($oauth2Response);
+
+        $mvcAuthEvent = $this->getMockBuilder('ZF\MvcAuth\MvcAuthEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $result = $this->adapter->authenticate(new HttpRequest, new HttpResponse, $mvcAuthEvent);
+        $this->assertInstanceOf('Zend\Http\Response', $result);
+        $this->assertEquals(403, $result->getStatusCode());
+    }
+
+    /**
+     * @group 83
+     */
+    public function testReturnsGuestIdentityIfOAuth2ResponseIsNotAnError()
+    {
+        $oauth2Response = $this->getMockBuilder('OAuth2\Response')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $oauth2Response
+            ->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(200);
+        $oauth2Response
+            ->expects($this->once())
+            ->method('getHttpHeaders')
+            ->willReturn(array());
+
+        $this->oauthServer
+            ->expects($this->once())
+            ->method('verifyResourceRequest')
+            ->with($this->callback(function ($subject) {
+                return ($subject instanceof OAuth2Request);
+            }))
+            ->willReturn(false);
+
+        $this->oauthServer
+            ->expects($this->once())
+            ->method('getResponse')
+            ->willReturn($oauth2Response);
+
+        $mvcAuthEvent = $this->getMockBuilder('ZF\MvcAuth\MvcAuthEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $result = $this->adapter->authenticate(new HttpRequest, new HttpResponse, $mvcAuthEvent);
+        $this->assertInstanceOf('ZF\MvcAuth\Identity\GuestIdentity', $result);
+    }
+
+    /**
+     * @group 83
+     */
+    public function testErrorResponseIncludesOAuth2ResponseHeaders()
+    {
+        $expectedHeaders = array(
+            'WWW-Authenticate' => 'Bearer realm="example.com", '
+            . 'scope="user", '
+            . 'error="unauthorized", '
+            . 'error_description="User has insufficient privileges"',
+        );
+        $oauth2Response = $this->getMockBuilder('OAuth2\Response')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $oauth2Response
+            ->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(401);
+        $oauth2Response
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with($this->equalTo('error'))
+            ->willReturn('invalid');
+        $oauth2Response
+            ->expects($this->once())
+            ->method('getHttpHeaders')
+            ->willReturn($expectedHeaders);
+
+        $this->oauthServer
+            ->expects($this->once())
+            ->method('verifyResourceRequest')
+            ->with($this->callback(function ($subject) {
+                return ($subject instanceof OAuth2Request);
+            }))
+            ->willReturn(false);
+
+        $this->oauthServer
+            ->expects($this->once())
+            ->method('getResponse')
+            ->willReturn($oauth2Response);
+
+        $mvcAuthEvent = $this->getMockBuilder('ZF\MvcAuth\MvcAuthEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $result = $this->adapter->authenticate(new HttpRequest, new HttpResponse, $mvcAuthEvent);
+        $this->assertInstanceOf('Zend\Http\Response', $result);
+
+        $headers = $result->getHeaders();
+        foreach ($expectedHeaders as $name => $value) {
+            $this->assertTrue($headers->has($name));
+            $header = $headers->get($name);
+            if ($header instanceof ArrayIterator) {
+                $found = false;
+                foreach ($header as $instance) {
+                    if ($instance->getFieldValue() == $value) {
+                        $found = true;
+                        break;
+                    }
+                }
+                $this->assertTrue($found, 'Expected header value not found');
+                continue;
+            }
+
+            $this->assertEquals($value, $header->getFieldValue());
+        }
+    }
+}


### PR DESCRIPTION
As requested on IRC I'm opening this issue to discuss about which status should return when token is expired. 

Right now when a token has expired, GuestIdentity is assigned which will cause a 403. 

The approach proposed by Matthew is to allow returning a 401 response from the authentication adapters. 

In the oauth adapter in line [149](https://github.com/zfcampus/zf-mvc-auth/blob/master/src/Authentication/OAuth2Adapter.php#L149) we should add logic to verify if it has expired and in that case return 401.

In my opinion returning 401 is more descriptive and also helps the compatibility (out of scope of this library) with http interceptor plugins like [angular-http-auth](https://github.com/witoldsz/angular-http-auth) which right now won't queue unauthorized requests to re-send later like it does with 401.

From [rfc6750](http://tools.ietf.org/html/rfc6750) page 8:

Error Codes

   When a request fails, the resource server responds using the
   appropriate HTTP status code (typically, 400, 401, 403, or 405) and
   includes one of the following error codes in the response:

   invalid_request
         The request is missing a required parameter, includes an
         unsupported parameter or parameter value, repeats the same
         parameter, uses more than one method for including an access
         token, or is otherwise malformed.  The resource server SHOULD
         respond with the HTTP 400 (Bad Request) status code.

   invalid_token
         **The access token provided is expired, revoked, malformed, or
         invalid for other reasons.  The resource SHOULD respond with
         the HTTP 401 (Unauthorized) status code.  The client MAY
         request a new access token and *retry* the protected resource
         request.**

   insufficient_scope
         The request requires higher privileges than provided by the
         access token.  The resource server SHOULD respond with the HTTP
         403 (Forbidden) status code and MAY include the "scope"
         attribute with the scope necessary to access the protected
         resource.
