### PR TITLE
Add option to configure custom resolver

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -65,16 +65,22 @@ return array(
              * For HttpAdapter cases, specify an 'options' key with the options
              * to use to create the Zend\Authentication\Adapter\Http instance.
              *
-             * Starting in 1.2, you can specify a resolver implementing the Zend\Authentication\Adapter\Http\ResolverInterface
-             * that is passed into the Zend\Authentication\Adapter\Http as either basic or digest resolver.
-             * This allows you to implement your own method of authentication instead of having to rely on the two
-             * default methods (ApacheResolver for basic authentication and FileResolver for digest authentication).
+             * Starting in 1.2, you can specify a resolver implementing the
+             * Zend\Authentication\Adapter\Http\ResolverInterface that is passed
+             * into the Zend\Authentication\Adapter\Http as either basic or digest
+             * resolver. This allows you to implement your own method of authentication
+             * instead of having to rely on the two default methods (ApacheResolver
+             * for basic authentication and FileResolver for digest authentication,
+             * both based on files).
              *
-             * When you want to use this feature, use the "basic_resolver_factory" key to get your custom resolver
-             * instance from the Zend service manager. If this key is set and pointing to a valid entry in the service
-             * manager, the entry "htpasswd" is ignored (unless you use it in your custom factory to build the resolver).
+             * When you want to use this feature, use the "basic_resolver_factory"
+             * key to get your custom resolver instance from the Zend service manager.
+             * If this key is set and pointing to a valid entry in the service manager,
+             * the entry "htpasswd" is ignored (unless you use it in your custom
+             * factory to build the resolver).
              *
-             * Using the "digest_resolver_factory" ignores the "htdigest" key in the same way.
+             * Using the "digest_resolver_factory" ignores the "htdigest" key in
+             * the same way.
              *
              * For OAuth2Adapter instances, specify a 'storage' key, with options
              * to use for matching the adapter and creating an OAuth2 storage

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -53,6 +53,8 @@ return array(
                 'nonce_timeout' => 3600,
                 'htpasswd' => APPLICATION_PATH . '/data/htpasswd' // htpasswd tool generated
                 'htdigest' => APPLICATION_PATH . '/data/htdigest' // @see http://www.askapache.com/online-tools/htpasswd-generator/
+                'basic_resolver_factory' => 'ServiceManagerKeyToAsk', // if this is set, the htpasswd key is ignored - see below
+                'digest_resolver_factory' => 'ServiceManagerKeyToAsk', // if this is set, the htdigest key is ignored - see below
             ),
              *
              * Starting in 1.1, we have an "adapters" key, which is a key/value
@@ -63,8 +65,19 @@ return array(
              * For HttpAdapter cases, specify an 'options' key with the options
              * to use to create the Zend\Authentication\Adapter\Http instance.
              *
+             * Starting in 1.2, you can specify a resolver implementing the Zend\Authentication\Adapter\Http\ResolverInterface
+             * that is passed into the Zend\Authentication\Adapter\Http as either basic or digest resolver.
+             * This allows you to implement your own method of authentication instead of having to rely on the two
+             * default methods (ApacheResolver for basic authentication and FileResolver for digest authentication).
+             *
+             * When you want to use this feature, use the "basic_resolver_factory" key to get your custom resolver
+             * instance from the Zend service manager. If this key is set and pointing to a valid entry in the service
+             * manager, the entry "htpasswd" is ignored (unless you use it in your custom factory to build the resolver).
+             *
+             * Using the "digest_resolver_factory" ignores the "htdigest" key in the same way.
+             *
              * For OAuth2Adapter instances, specify a 'storage' key, with options
-             * to use for matching the adapter and creating an OAuth2 storage 
+             * to use for matching the adapter and creating an OAuth2 storage
              * instance. The array MUST contain a `route' key, with the route
              * at which the specific adapter will match authentication requests.
              * To specify the storage instance, you may use one of two approaches:
@@ -89,6 +102,8 @@ return array(
                         'nonce_timeout' => 3600,
                         'htpasswd' => 'data/htpasswd',
                         'htdigest' => 'data/htdigest',
+                        'basic_resolver_factory' => 'ServiceManagerKeyToAsk', // if this is set, the htpasswd key is ignored
+                        'digest_resolver_factory' => 'ServiceManagerKeyToAsk', // if this is set, the htdigest key is ignored
                     ),
                 ),
                 // OAuth2 adapter, using an "adapter" type of "pdo"

--- a/src/Factory/AuthenticationHttpAdapterFactory.php
+++ b/src/Factory/AuthenticationHttpAdapterFactory.php
@@ -42,7 +42,7 @@ final class AuthenticationHttpAdapterFactory
         }
 
         return new HttpAdapter(
-            HttpAdapterFactory::factory($config['options']),
+            HttpAdapterFactory::factory($config['options'], $services),
             $services->get('authentication'),
             $type
         );

--- a/src/Factory/DefaultAuthHttpAdapterFactory.php
+++ b/src/Factory/DefaultAuthHttpAdapterFactory.php
@@ -35,6 +35,6 @@ class DefaultAuthHttpAdapterFactory implements FactoryInterface
             return false;
         }
 
-        return HttpAdapterFactory::factory($config['zf-mvc-auth']['authentication']['http']);
+        return HttpAdapterFactory::factory($config['zf-mvc-auth']['authentication']['http'], $services);
     }
 }

--- a/src/Factory/HttpAdapterFactory.php
+++ b/src/Factory/HttpAdapterFactory.php
@@ -30,7 +30,7 @@ final class HttpAdapterFactory
      * @param array $config
      * @param ServiceLocatorInterface $serviceLocator
      * @return HttpAuth
-     * @throws ServiceNotCreatedException
+     * @throws ServiceNotCreatedException if any required elements are missing
      */
     public static function factory(array $config, ServiceLocatorInterface $serviceLocator = null)
     {

--- a/test/Factory/HttpAdapterFactoryTest.php
+++ b/test/Factory/HttpAdapterFactoryTest.php
@@ -175,10 +175,18 @@ class HttpAdapterFactoryTest extends TestCase
         $keyForServiceManager = 'keyForServiceManager';
 
         $serviceManager = $this->getMock('\Zend\ServiceManager\ServiceLocatorInterface');
-        $serviceManager->expects($this->once())->method('has')->with($keyForServiceManager)->will($this->returnValue(true));
+        $serviceManager
+            ->expects($this->once())
+            ->method('has')
+            ->with($keyForServiceManager)
+            ->will($this->returnValue(true));
 
         $resolver = $this->getMock('\Zend\Authentication\Adapter\Http\ResolverInterface');
-        $serviceManager->expects($this->once())->method('get')->with($keyForServiceManager)->will($this->returnValue($resolver));
+        $serviceManager
+            ->expects($this->once())
+            ->method('get')
+            ->with($keyForServiceManager)
+            ->will($this->returnValue($resolver));
 
         $adapter = HttpAdapterFactory::factory(array(
             'accept_schemes' => array('basic', 'digest'),
@@ -199,10 +207,18 @@ class HttpAdapterFactoryTest extends TestCase
         $keyForServiceManager = 'keyForServiceManager';
 
         $serviceManager = $this->getMock('\Zend\ServiceManager\ServiceLocatorInterface');
-        $serviceManager->expects($this->once())->method('has')->with($keyForServiceManager)->will($this->returnValue(true));
+        $serviceManager
+            ->expects($this->once())
+            ->method('has')
+            ->with($keyForServiceManager)
+            ->will($this->returnValue(true));
 
         $resolver = $this->getMock('\Zend\Authentication\Adapter\Http\ResolverInterface');
-        $serviceManager->expects($this->once())->method('get')->with($keyForServiceManager)->will($this->returnValue($resolver));
+        $serviceManager
+            ->expects($this->once())
+            ->method('get')
+            ->with($keyForServiceManager)
+            ->will($this->returnValue($resolver));
 
         $adapter = HttpAdapterFactory::factory(array(
             'accept_schemes' => array('basic', 'digest'),
@@ -258,8 +274,14 @@ class HttpAdapterFactoryTest extends TestCase
         $missingKeyForServiceManager = 'missingKeyForServiceManager';
 
         $serviceManager = $this->getMock('\Zend\ServiceManager\ServiceLocatorInterface');
-        $serviceManager->expects($this->any())->method('has')->with($missingKeyForServiceManager)->will($this->returnValue(false));
-        $serviceManager->expects($this->never())->method('get');
+        $serviceManager
+            ->expects($this->any())
+            ->method('has')
+            ->with($missingKeyForServiceManager)
+            ->will($this->returnValue(false));
+        $serviceManager
+            ->expects($this->never())
+            ->method('get');
 
         $adapter = HttpAdapterFactory::factory(array(
             'accept_schemes' => array('basic', 'digest'),
@@ -274,8 +296,4 @@ class HttpAdapterFactoryTest extends TestCase
         $this->assertNull($adapter->getBasicResolver());
         $this->assertNull($adapter->getDigestResolver());
     }
-
-
-
-
 }

--- a/test/Factory/HttpAdapterFactoryTest.php
+++ b/test/Factory/HttpAdapterFactoryTest.php
@@ -11,6 +11,9 @@ use ZF\MvcAuth\Factory\HttpAdapterFactory;
 
 class HttpAdapterFactoryTest extends TestCase
 {
+    private $htpasswd;
+    private $htdigest;
+
     public function setUp()
     {
         $this->htpasswd = __DIR__ . '/../TestAsset/htpasswd';
@@ -166,4 +169,113 @@ class HttpAdapterFactoryTest extends TestCase
         $this->assertInstanceOf('Zend\Authentication\Adapter\Http\ApacheResolver', $adapter->getBasicResolver());
         $this->assertInstanceOf('Zend\Authentication\Adapter\Http\FileResolver', $adapter->getDigestResolver());
     }
+
+    public function testCanReturnBasicAdapterWithCustomResolverFromServiceManager()
+    {
+        $keyForServiceManager = 'keyForServiceManager';
+
+        $serviceManager = $this->getMock('\Zend\ServiceManager\ServiceLocatorInterface');
+        $serviceManager->expects($this->once())->method('has')->with($keyForServiceManager)->will($this->returnValue(true));
+
+        $resolver = $this->getMock('\Zend\Authentication\Adapter\Http\ResolverInterface');
+        $serviceManager->expects($this->once())->method('get')->with($keyForServiceManager)->will($this->returnValue($resolver));
+
+        $adapter = HttpAdapterFactory::factory(array(
+            'accept_schemes' => array('basic', 'digest'),
+            'realm' => 'api',
+            'digest_domains' => 'https://example.com',
+            'nonce_timeout' => 3600,
+            'htpasswd' => $this->htpasswd,
+            'basic_resolver_factory' => $keyForServiceManager,
+        ), $serviceManager);
+
+        $this->assertInstanceOf('Zend\Authentication\Adapter\Http', $adapter);
+        $this->assertSame($resolver, $adapter->getBasicResolver());
+        $this->assertNull($adapter->getDigestResolver());
+    }
+
+    public function testCanReturnDigestAdapterWithCustomResolverFromServiceManager()
+    {
+        $keyForServiceManager = 'keyForServiceManager';
+
+        $serviceManager = $this->getMock('\Zend\ServiceManager\ServiceLocatorInterface');
+        $serviceManager->expects($this->once())->method('has')->with($keyForServiceManager)->will($this->returnValue(true));
+
+        $resolver = $this->getMock('\Zend\Authentication\Adapter\Http\ResolverInterface');
+        $serviceManager->expects($this->once())->method('get')->with($keyForServiceManager)->will($this->returnValue($resolver));
+
+        $adapter = HttpAdapterFactory::factory(array(
+            'accept_schemes' => array('basic', 'digest'),
+            'realm' => 'api',
+            'digest_domains' => 'https://example.com',
+            'nonce_timeout' => 3600,
+            'htdigest' => $this->htdigest,
+            'digest_resolver_factory' => $keyForServiceManager,
+        ), $serviceManager);
+
+        $this->assertInstanceOf('Zend\Authentication\Adapter\Http', $adapter);
+        $this->assertNull($adapter->getBasicResolver());
+        $this->assertSame($resolver, $adapter->getDigestResolver());
+    }
+
+    public function testCanReturnAdapterWithNoResolversAndInvalidServiceManager()
+    {
+        $adapter = HttpAdapterFactory::factory(array(
+            'accept_schemes' => array('basic', 'digest'),
+            'realm' => 'api',
+            'digest_domains' => 'https://example.com',
+            'nonce_timeout' => 3600,
+            'basic_resolver_factory' => 'uselessKeyDueToMissingServiceManager',
+            'digest_resolver_factory' => 'uselessKeyDueToMissingServiceManager',
+        ));
+
+        $this->assertInstanceOf('Zend\Authentication\Adapter\Http', $adapter);
+        $this->assertNull($adapter->getBasicResolver());
+        $this->assertNull($adapter->getDigestResolver());
+    }
+
+    public function testCanReturnAdapterWithNoResolversAndInvalidResolverKeys()
+    {
+        $serviceManager = $this->getMock('\Zend\ServiceManager\ServiceLocatorInterface');
+        $serviceManager->expects($this->never())->method('has');
+
+        $adapter = HttpAdapterFactory::factory(array(
+            'accept_schemes' => array('basic', 'digest'),
+            'realm' => 'api',
+            'digest_domains' => 'https://example.com',
+            'nonce_timeout' => 3600,
+            'basic_resolver_factory' => null,
+            'digest_resolver_factory' => array(),
+        ), $serviceManager);
+
+        $this->assertInstanceOf('Zend\Authentication\Adapter\Http', $adapter);
+        $this->assertNull($adapter->getBasicResolver());
+        $this->assertNull($adapter->getDigestResolver());
+    }
+
+    public function testCanReturnAdapterWithNoResolversAndMissingServiceManagerEntries()
+    {
+        $missingKeyForServiceManager = 'missingKeyForServiceManager';
+
+        $serviceManager = $this->getMock('\Zend\ServiceManager\ServiceLocatorInterface');
+        $serviceManager->expects($this->any())->method('has')->with($missingKeyForServiceManager)->will($this->returnValue(false));
+        $serviceManager->expects($this->never())->method('get');
+
+        $adapter = HttpAdapterFactory::factory(array(
+            'accept_schemes' => array('basic', 'digest'),
+            'realm' => 'api',
+            'digest_domains' => 'https://example.com',
+            'nonce_timeout' => 3600,
+            'basic_resolver_factory' => $missingKeyForServiceManager,
+            'digest_resolver_factory' => $missingKeyForServiceManager,
+        ), $serviceManager);
+
+        $this->assertInstanceOf('Zend\Authentication\Adapter\Http', $adapter);
+        $this->assertNull($adapter->getBasicResolver());
+        $this->assertNull($adapter->getDigestResolver());
+    }
+
+
+
+
 }


### PR DESCRIPTION
resolves #84 

Utilizes the service manager to provide an implementation for either basic and/or digest authentication methods, overriding the default ApacheResolver and FileResolver.