### PR TITLE
Resolve #86: Improve testing, remove version restriction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,31 @@ matrix:
   fast_finish: true
   include:
     - php: 5.3
+      env:
+        - deps=high
     - php: 5.4
+      env:
+        - deps=high
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+        - deps=high
     - php: 5.6
       env:
         - EXECUTE_COVERAGE=true
+        - deps=high
+    - php: 5.6
+      env:
+        - deps=low
     - php: 7
-    - php: hhvm 
+      env:
+        - deps=high
+    - php: 7
+      env:
+        - deps=low
+    - php: hhvm
+      env:
+        - deps=high
   allow_failures:
     - php: 7
     - php: hhvm
@@ -32,6 +48,8 @@ before_install:
   - composer self-update
 
 install:
+  - if [[ "$deps" = "high" ]]; then travis_retry composer --no-interaction --prefer-source update;  fi;
+  - if [[ "$deps" = "low" ]]; then travis_retry composer --no-interaction --prefer-source --prefer-lowest update;  fi;
   - travis_retry composer install --no-interaction --ignore-platform-reqs --prefer-source
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "zendframework/zend-stdlib": "~2.3",
         "zfcampus/zf-api-problem": "~1.0",
         "zfcampus/zf-content-negotiation": "~1.0",
-        "zfcampus/zf-oauth2": "^1.1.1"
+        "zfcampus/zf-oauth2": "^1.1.1",
+        "bshaffer/oauth2-server-php": "~1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
     },
     "require": {
         "php": ">=5.3.23",
-        "zendframework/zend-authentication": ">=2.3,<2.5",
-        "zendframework/zend-eventmanager": ">=2.3,<2.5",
-        "zendframework/zend-http": ">=2.3,<2.5",
-        "zendframework/zend-mvc": ">=2.3,<2.5",
-        "zendframework/zend-permissions-acl": ">=2.3,<2.5",
-        "zendframework/zend-permissions-rbac": ">=2.3,<2.5",
-        "zendframework/zend-servicemanager": ">=2.3,<2.5",
-        "zendframework/zend-stdlib": ">=2.3,<2.5",
+        "zendframework/zend-authentication": "~2.3",
+        "zendframework/zend-eventmanager": "~2.3",
+        "zendframework/zend-http": "~2.3",
+        "zendframework/zend-mvc": "~2.3",
+        "zendframework/zend-permissions-acl": "~2.3",
+        "zendframework/zend-permissions-rbac": "~2.3",
+        "zendframework/zend-servicemanager": "~2.3",
+        "zendframework/zend-stdlib": "~2.3",
         "zfcampus/zf-api-problem": "~1.0",
         "zfcampus/zf-content-negotiation": "~1.0",
         "zfcampus/zf-oauth2": "^1.1.1"
@@ -34,8 +34,8 @@
     "require-dev": {
         "phpunit/phpunit": "~4.7",
         "squizlabs/php_codesniffer": "^2.3",
-        "zendframework/zend-loader": ">=2.3,<2.5",
-        "zendframework/zend-session": ">=2.3,<2.5"
+        "zendframework/zend-loader": "~2.3",
+        "zendframework/zend-session": "~2.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The travis script now does updates for all PHP versions before execution.
PHP 5.6 and 7 tests are also executed with the lowest possible dependency version. This revealed an incompatibility with the allowed "bshaffer/oauth2-server-php" - forcing the minimum version to be ~1.4 resolved it.