### PR TITLE
Only register listeners for HTTP requests

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -6,6 +6,7 @@
 
 namespace ZF\MvcAuth;
 
+use Zend\Http\Request as HttpRequest;
 use Zend\ModuleManager\ModuleEvent;
 use Zend\ModuleManager\ModuleManager;
 use Zend\Mvc\MvcEvent;
@@ -74,6 +75,10 @@ class Module
 
     public function onBootstrap(MvcEvent $mvcEvent)
     {
+        if (! $mvcEvent->getRequest() instanceof HttpRequest) {
+            return;
+        }
+
         $app      = $mvcEvent->getApplication();
         $events   = $app->getEventManager();
         $this->services = $app->getServiceManager();

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\MvcAuth;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
+use ZF\MvcAuth\Module;
+use ZF\MvcAuth\MvcAuthEvent;
+
+class ModuleTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->mvcEvent = $mvcEvent = $this->prophesize('Zend\Mvc\MvcEvent');
+        $this->module = new Module();
+    }
+
+    public function setUpApplication()
+    {
+        $services = $this->setUpServices();
+        $events   = $this->setUpEvents();
+
+        $application = $this->prophesize('Zend\Mvc\Application');
+        $application->getEventManager()->will(function () use ($events) {
+            return $events->reveal();
+        });
+        $application->getServiceManager()->will(function () use ($services) {
+            return $services->reveal();
+        });
+        
+        return $application;
+    }
+
+    public function setUpServices()
+    {
+        $authentication = $this->prophesize('Zend\Authentication\AuthenticationService');
+        $authorization  = $this->prophesize('ZF\MvcAuth\Authorization\AuthorizationInterface');
+        $defaultAuthenticationListener = $this->prophesize(
+            'ZF\MvcAuth\Authentication\DefaultAuthenticationListener'
+        );
+        $defaultAuthenticationPostListener = $this->prophesize(
+            'ZF\MvcAuth\Authentication\DefaultAuthenticationPostListener'
+        );
+        $defaultResourceResolverListener = $this->prophesize(
+            'ZF\MvcAuth\Authorization\DefaultResourceResolverListener'
+        );
+        $defaultAuthorizationListener = $this->prophesize(
+            'ZF\MvcAuth\Authorization\DefaultAuthorizationListener'
+        );
+        $defaultAuthorizationPostListener = $this->prophesize(
+            'ZF\MvcAuth\Authorization\DefaultAuthorizationPostListener'
+        );
+
+        $services = $this->prophesize('Zend\ServiceManager\ServiceLocatorInterface');
+        $services->get('authentication')->will(function () use ($authentication) {
+            return $authentication->reveal();
+        });
+        $services->get('authorization')->will(function () use ($authorization) {
+            return $authorization->reveal();
+        });
+        $services->get('ZF\MvcAuth\Authentication\DefaultAuthenticationListener')
+            ->will(function () use ($defaultAuthenticationListener) {
+                return $defaultAuthenticationListener->reveal();
+            });
+        $services->get('ZF\MvcAuth\Authentication\DefaultAuthenticationPostListener')
+            ->will(function () use ($defaultAuthenticationPostListener) {
+                return $defaultAuthenticationPostListener->reveal();
+            });
+        $services->get('ZF\MvcAuth\Authorization\DefaultResourceResolverListener')
+            ->will(function () use ($defaultResourceResolverListener) {
+                return $defaultResourceResolverListener->reveal();
+            });
+        $services->get('ZF\MvcAuth\Authorization\DefaultAuthorizationListener')
+            ->will(function () use ($defaultAuthorizationListener) {
+                return $defaultAuthorizationListener->reveal();
+            });
+        $services->get('ZF\MvcAuth\Authorization\DefaultAuthorizationPostListener')
+            ->will(function () use ($defaultAuthorizationPostListener) {
+                return $defaultAuthorizationPostListener->reveal();
+            });
+
+        return $services;
+    }
+
+    public function setUpEvents()
+    {
+        $events = $this->prophesize('Zend\EventManager\EventManagerInterface');
+
+        $events->attach(Argument::type('ZF\MvcAuth\MvcRouteListener'));
+
+        $events->attach(
+            MvcAuthEvent::EVENT_AUTHENTICATION,
+            Argument::type('ZF\MvcAuth\Authentication\DefaultAuthenticationListener')
+        );
+        $events->attach(
+            MvcAuthEvent::EVENT_AUTHENTICATION_POST,
+            Argument::type('ZF\MvcAuth\Authentication\DefaultAuthenticationPostListener')
+        );
+        $events->attach(
+            MvcAuthEvent::EVENT_AUTHORIZATION,
+            Argument::type('ZF\MvcAuth\Authorization\DefaultResourceResolverListener'),
+            1000
+        );
+        $events->attach(
+            MvcAuthEvent::EVENT_AUTHORIZATION,
+            Argument::type('ZF\MvcAuth\Authorization\DefaultAuthorizationListener')
+        );
+        $events->attach(
+            MvcAuthEvent::EVENT_AUTHORIZATION_POST,
+            Argument::type('ZF\MvcAuth\Authorization\DefaultAuthorizationPostListener')
+        );
+        $events->attach(
+            MvcAuthEvent::EVENT_AUTHENTICATION_POST,
+            Argument::is(array($this->module, 'onAuthenticationPost')),
+            -1
+        );
+
+        return $events;
+    }
+
+    public function testOnBootstrapReturnsEarlyForNonHttpEvents()
+    {
+        $request = $this->prophesize('Zend\Stdlib\RequestInterface');
+        $this->mvcEvent->getRequest()->will(function () use ($request) {
+            return $request->reveal();
+        });
+        $this->module->onBootstrap($this->mvcEvent->reveal());
+    }
+
+    public function testOnBootstrapAttachesListeners()
+    {
+        $mvcEvent    = $this->mvcEvent;
+        $request     = $this->prophesize('Zend\Http\Request');
+        $application = $this->setUpApplication();
+        $mvcEvent->getRequest()->will(function () use ($request) {
+            return $request->reveal();
+        });
+        $mvcEvent->getApplication()->will(function () use ($application) {
+            return $application->reveal();
+        });
+        $this->module->onBootstrap($mvcEvent->reveal());
+    }
+}


### PR DESCRIPTION
Based on a report from @jguittard via ContinuousPHP, registering the mvc-auth listeners can have ill effects if not in an HTTP environment and/or the local configuration for OAuth2 is missing (which is often the case when packaging for deployment). This patch adds code to `onBootstrap()` to return early, without registering listeners, if a non-HTTP request is made.