### PR TITLE
Fixed #92

### DIFF
--- a/src/Authentication/HttpAdapter.php
+++ b/src/Authentication/HttpAdapter.php
@@ -120,7 +120,7 @@ class HttpAdapter extends AbstractAdapter
      */
     public function authenticate(Request $request, Response $response, MvcAuthEvent $mvcAuthEvent)
     {
-        if($request->getHeader('Authorization') !== false) {
+        if ($request->getHeader('Authorization') !== false) {
             $this->httpAuth->setRequest($request);
             $this->httpAuth->setResponse($response);
 

--- a/src/Authentication/HttpAdapter.php
+++ b/src/Authentication/HttpAdapter.php
@@ -120,30 +120,35 @@ class HttpAdapter extends AbstractAdapter
      */
     public function authenticate(Request $request, Response $response, MvcAuthEvent $mvcAuthEvent)
     {
-        $this->httpAuth->setRequest($request);
-        $this->httpAuth->setResponse($response);
+        if($request->getHeader('Authorization') !== false) {
+            $this->httpAuth->setRequest($request);
+            $this->httpAuth->setResponse($response);
 
-        $result = $this->authenticationService->authenticate($this->httpAuth);
-        $mvcAuthEvent->setAuthenticationResult($result);
+            $result = $this->authenticationService->authenticate($this->httpAuth);
+            $mvcAuthEvent->setAuthenticationResult($result);
 
-        if (! $result->isValid()) {
-            return false;
+            if (!$result->isValid()) {
+                return false;
+            }
+
+            $resultIdentity = $result->getIdentity();
+
+            // Pass fully discovered identity to AuthenticatedIdentity instance
+            $identity = new Identity\AuthenticatedIdentity($resultIdentity);
+
+            // But determine the name separately
+            $name = $resultIdentity;
+            if (is_array($resultIdentity)) {
+                $name = isset($resultIdentity['username'])
+                    ? $resultIdentity['username']
+                    : (string)array_shift($resultIdentity);
+            }
+            $identity->setName($name);
+
+            return $identity;
+        } else {
+            // No credentials were present at all, so we just return a guest identity.
+            return new Identity\GuestIdentity();
         }
-
-        $resultIdentity = $result->getIdentity();
-
-        // Pass fully discovered identity to AuthenticatedIdentity instance
-        $identity = new Identity\AuthenticatedIdentity($resultIdentity);
-
-        // But determine the name separately
-        $name = $resultIdentity;
-        if (is_array($resultIdentity)) {
-            $name = isset($resultIdentity['username'])
-                ? $resultIdentity['username']
-                : (string) array_shift($resultIdentity);
-        }
-        $identity->setName($name);
-
-        return $identity;
     }
 }


### PR DESCRIPTION
Per #92 (and zfcampus/zf-apigility-skeleton#104), HTTP authentication starting in 1.1 is now updating the Response instance and injecting a 401 status when no credentials are provided. This situation disables public access to an API using HTTP auth, making it de facto private regardless of authorization rules.