### PR TITLE
Fixing Issue #101

### DIFF
--- a/src/Authentication/HttpAdapter.php
+++ b/src/Authentication/HttpAdapter.php
@@ -120,10 +120,11 @@ class HttpAdapter extends AbstractAdapter
      */
     public function authenticate(Request $request, Response $response, MvcAuthEvent $mvcAuthEvent)
     {
-        if (! $request->getHeader('Authorization', false)) {
-            // No credentials were present at all, so we just return a guest identity.
-            return new Identity\GuestIdentity();
-        }
+        /**
+         * With or without credential we call the authentication service.
+         * In case of no credentials the service should trigger the authentication
+         * challenge according to the configured method (Basic or Digest)
+         */
 
         $this->httpAuth->setRequest($request);
         $this->httpAuth->setResponse($response);


### PR DESCRIPTION
When a service is configured with Basic or Digest authentication, the auth challenge should be triggered when the inherent header is missing, with a 401 status returned.
RIght now the challenge is triggered only when the auth header is present and its parameters do not calculate properly.