### PR TITLE
Fix #97 and #106

### DIFF
--- a/src/Authentication/HttpAdapter.php
+++ b/src/Authentication/HttpAdapter.php
@@ -120,11 +120,6 @@ class HttpAdapter extends AbstractAdapter
      */
     public function authenticate(Request $request, Response $response, MvcAuthEvent $mvcAuthEvent)
     {
-        if (! $request->getHeader('Authorization', false)) {
-            // No credentials were present at all, so we just return a guest identity.
-            return new Identity\GuestIdentity();
-        }
-
         $this->httpAuth->setRequest($request);
         $this->httpAuth->setResponse($response);
 

--- a/src/Authorization/DefaultAuthorizationListener.php
+++ b/src/Authorization/DefaultAuthorizationListener.php
@@ -70,8 +70,6 @@ class DefaultAuthorizationListener
         // by authentication layer. This avoid challenging client in case a
         // guest identity is allowed to access the resource after all.
         if ($isAuthorized) {
-            // Resetting response set on mvc event is not sufficient
-            // This denote another problem which
             $app = $mvcEvent->getApplication();
             $response = $app->getResponse();
 

--- a/src/Authorization/DefaultAuthorizationPostListener.php
+++ b/src/Authorization/DefaultAuthorizationPostListener.php
@@ -23,15 +23,19 @@ class DefaultAuthorizationPostListener
         $response = $mvcEvent->getResponse();
 
         if ($mvcAuthEvent->isAuthorized()) {
-            if ($response instanceof HttpResponse) {
-                if ($response->getStatusCode() != 200) {
-                    $response->setStatusCode(200);
-                }
+            if ($response instanceof HttpResponse
+                && $response->getStatusCode() != 200
+            ) {
+                $response->setStatusCode(200);
             }
             return;
         }
 
-        if (!$response instanceof HttpResponse) {
+        // If no HTTP response, or an HTTP response already denoting a problem,
+        // return it immediately
+        if (!$response instanceof HttpResponse
+            || $response->getStatusCode() == 401
+        ) {
             return $response;
         }
 

--- a/test/Authentication/HttpAdapterTest.php
+++ b/test/Authentication/HttpAdapterTest.php
@@ -37,21 +37,6 @@ class HttpAdapterTest extends TestCase
         );
     }
 
-    /*public function testAuthenticateReturnsGuestIdentityIfNoAuthorizationHeaderProvided()
-    {
-        $httpAuth = new HttpAuth([
-            'accept_schemes' => 'basic',
-            'realm' => 'My Web Site',
-            'digest_domains' => '/',
-            'nonce_timeout' => 3600,
-        ]);
-        $httpAuth->setBasicResolver(new HttpAuth\ApacheResolver(__DIR__ . '/../TestAsset/htpasswd'));
-
-        $adapter = new HttpAdapter($httpAuth, $this->authentication);
-        $result  = $adapter->authenticate($this->request, $this->response, $this->event);
-        $this->assertInstanceOf('ZF\MvcAuth\Identity\GuestIdentity', $result);
-    }*/
-
     public function testAuthenticateReturnsFalseIfInvalidCredentialsProvidedInAuthorizationHeader()
     {
         $httpAuth = new HttpAuth([

--- a/test/Authentication/HttpAdapterTest.php
+++ b/test/Authentication/HttpAdapterTest.php
@@ -37,7 +37,7 @@ class HttpAdapterTest extends TestCase
         );
     }
 
-    public function testAuthenticateReturnsGuestIdentityIfNoAuthorizationHeaderProvided()
+    /*public function testAuthenticateReturnsGuestIdentityIfNoAuthorizationHeaderProvided()
     {
         $httpAuth = new HttpAuth([
             'accept_schemes' => 'basic',
@@ -50,7 +50,7 @@ class HttpAdapterTest extends TestCase
         $adapter = new HttpAdapter($httpAuth, $this->authentication);
         $result  = $adapter->authenticate($this->request, $this->response, $this->event);
         $this->assertInstanceOf('ZF\MvcAuth\Identity\GuestIdentity', $result);
-    }
+    }*/
 
     public function testAuthenticateReturnsFalseIfInvalidCredentialsProvidedInAuthorizationHeader()
     {

--- a/test/Authorization/DefaultAuthorizationPostListenerTest.php
+++ b/test/Authorization/DefaultAuthorizationPostListenerTest.php
@@ -58,6 +58,17 @@ class DefaultAuthorizationPostListenerTest extends TestCase
         $this->assertSame($response, $listener($this->mvcAuthEvent));
     }
 
+    public function testReturns401ResponseWhenNotAuthenticatedAndNotAuthorized()
+    {
+        $listener = $this->listener;
+        $response = $this->mvcAuthEvent->getMvcEvent()->getResponse();
+        $response->setStatusCode('401');
+        $this->mvcAuthEvent->setIsAuthorized(false);
+        $this->assertSame($response, $listener($this->mvcAuthEvent));
+        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertEquals('Unauthorized', $response->getReasonPhrase());
+    }
+
     public function testReturns403ResponseWhenNotAuthorizedAndHttpResponseComposed()
     {
         $listener = $this->listener;


### PR DESCRIPTION
PR which allows to fix/close the following issues: #97 and #106

First of all, it should be noted that explainations below assume that #92 was never merged. That fix was a mistake and it is reverted by this new PR. See #106 for more details about #92 mistakes.

## Expected behavior

- If a resource is private, client must be authenticated to access it. If it is not, it must be challenged with a **401** response
- If a resource is public, client must be allowed to access it, even if not authenticated (case of a guest identity)
- If client is authenticated but not authorized to access a resource (case of an authenticated identity with extended permissions system), a **403** response must be returned.

## Current behavior

Authentication is needed for public and private resources, even if the developer makes them public. This is due to the fact that at the authentication level (authenticationPost), we are returning the response, leading to short-circuit of the route event on which authorization listeners are also attached (they have a lower priority than authentication listeners).

Thus, returning a response from the authentication layer, in case of an authentication failure or if the client get challenged, means that authorization rules for a guest identity are never evaluated and therefore, public resources are not because authentication is always required.

## New behavior

### Authentication layer

- In case of an authentication failure, the response is no longer returned. We ensure that the response is set on the **MvcEvent** instead. This allows to not short-circuit the route event, and thus, evaluate authorization rules in the context of a guest identity prior returning the response.

### Authorization layer

- If the client is authorized to access the resource, the MVC response which can have been modified by authentication layer is reseted. This avoid challenging the client in case of a guest identity that is allowed to access the resource after all (public resources).
- The response, if already an **ApiResponseProblem** instance, is not overriden by the **ZF\Apigility\MvcAuth\UnauthorizedListener** listener. This allows sending correct response (**401**) in case of an authentication failure. (A separated PR for the zf-apigility module will be made according this change).

## About 401 status code vs 403 status code

Generally speaking, the **403** status code involves an authenticated user. User is authenticated but is not authorized to access the requested resource. This is generally the case when an authenticated user try to access resource owned by another user.

Currently, Apigility provides a very basic permissions system, based on HTTP methods and static identities. Access to a resource requires either an authenticated identity or a guest identity. The extended permissions system implementation, if it is required, is left to the developer. Of course, a **403** response is still send by the authorization layer in case of an unauthorized client, but only if no authentication is required (case of an already authenticated user). This will be the case if the developer implements extended permissions system (e.g, conditional ACL with assertions).

Regarding the above, it should be noted that even if authentication and authorization layers have differents concerns, this doesn't prevent one layer (e.g. the authorization layer) to be aware of the other. Furthermore, it shouldn't be forgotten that these layers are intimately linked. In other words, we can see the zf-mvc-auth module as a component that provides sub-components (authentication, authorization) which are coworkers. As such, they can share information.

Final note: Sorry for the verbosity here. I wanted to be as clear as possible.