### PR TITLE
Correct docs for deny_by_default and zf-oauth2 route permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,30 +247,22 @@ Example:
 'deny_by_default' => false,
 ```
 
-> ##### deny_by_default with zf-oauth2
->
-> When using `deny_by_default => true` with > [zf-oauth2](https://github.com/zfcampus/zf-oauth2),
-> you will need to explicitly allow POST on the OAuth2 controller in order for Authentication
-> requests to be made.
-> 
-> As an example:
->
-> ```php
-> `authorization` => array(
->     'deny_by_default' => true,
->     'ZF\\OAuth2\\Controller\\Auth' => array(
->         'actions' => array(
->             'token' => array(
->                 'GET'    => false,
->                 'POST'   => true,   // <-----
->                 'PATCH'  => false,
->                 'PUT'    => false,
->                 'DELETE' => false,
->             ),
->         ),
->     ),
-> ),
-> ```
+##### deny_by_default with zf-oauth2
+
+When using `deny_by_default => true` with [zf-oauth2](https://github.com/zfcampus/zf-oauth2) you must explicitly allow POST on the OAuth2 controller in order for Authentication requests to be made.
+ 
+```php
+'authorization' => array(
+    'deny_by_default' => true,
+    'ZF\\OAuth2\\Controller\\Auth' => array(
+        'actions' => array(
+            'token' => array(
+                'POST'   => false,   // <-- explictly exclude authentication
+            ),
+        ),
+    ),
+),
+ ```
 
 #### Sub-Key: Controller Service Name
 


### PR DESCRIPTION
The documentation was basackwards in deny_by_default example with zf-oauth2.