### PR TITLE
Complete forwards compatibility with v3 ZF component releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-composer.lock
 vendor/
 .idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,44 @@ language: php
 cache:
   directories:
     - $HOME/.composer/cache
+    - vendor
+
+env:
+  global:
+    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
-      env:
-        - EXECUTE_CS_CHECK=true
     - php: 5.6
       env:
-        - EXECUTE_COVERAGE=true
+        - DEPS=lowest
+    - php: 5.6
+      env:
+        - DEPS=locked
+    - php: 5.6
+      env:
+        - DEPS=latest
     - php: 7
+      env:
+        - DEPS=lowest
+    - php: 7
+      env:
+        - DEPS=locked
+        - CS_CHECK=true
+    - php: 7
+      env:
+        - DEPS=latest
     - php: hhvm 
+      env:
+        - DEPS=lowest
+    - php: hhvm 
+      env:
+        - DEPS=locked
+    - php: hhvm 
+      env:
+        - DEPS=latest
   allow_failures:
-    - php: 7
     - php: hhvm
   
 notifications:
@@ -26,12 +50,15 @@ notifications:
   email: false
 
 before_install:
-  - if [[ $EXECUTE_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - composer self-update
+  - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
+  - travis_retry composer self-update
 
 install:
-  - travis_retry composer install --no-interaction --ignore-platform-reqs --prefer-source
+  - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
+  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
+  - travis_retry composer install $COMPOSER_ARGS
+  - composer show
 
 script:
-  - ./vendor/bin/phpunit
-  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/phpcs ; fi
+  - composer test
+  - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
         "branch-alias": {
             "dev-master": "1.3-dev",
             "dev-develop": "1.4-dev"
+        },
+        "zf": {
+            "module": "ZF\\MvcAuth"
         }
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,67 +1,54 @@
 {
-  "name": "zfcampus/zf-mvc-auth",
-  "description": "ZF2 Module providing Authentication and Authorization events and infrastructure",
-  "type": "library",
-  "license": "BSD-3-Clause",
-  "keywords": [
-    "zf2",
-    "zend",
-    "module"
-  ],
-  "repositories": [
-    {
-      "type": "composer",
-      "url": "https://packages.zendframework.com"
+    "name": "zfcampus/zf-mvc-auth",
+    "description": "ZF2 Module providing Authentication and Authorization events and infrastructure",
+    "type": "library",
+    "license": "BSD-3-Clause",
+    "keywords": [
+        "zf2",
+        "zend",
+        "module"
+    ],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.3-dev",
+            "dev-develop": "1.4-dev"
+        }
     },
-    {
-      "type": "vcs",
-      "url": "https://github.com/AGmakonts/zf-content-negotiation.git"
+    "require": {
+        "zendframework/zend-authentication": "^2.5.3",
+        "zendframework/zend-eventmanager": "^2.6.3 || ^3.0.1",
+        "zendframework/zend-http": "^2.5.4",
+        "zendframework/zend-mvc": "^2.7.9 || ^3.0.2",
+        "zendframework/zend-permissions-acl": "^2.6",
+        "zendframework/zend-permissions-rbac": "^2.5.1",
+        "zendframework/zend-servicemanager": "^2.7.6 || ^3.1",
+        "zendframework/zend-stdlib": "^2.7.7 || ^3.0.1",
+        "zfcampus/zf-api-problem": "^1.2.1",
+        "zfcampus/zf-content-negotiation": "^1.2.1",
+        "zfcampus/zf-oauth2": "^1.4"
     },
-    {
-      "type": "vcs",
-      "url": "https://github.com/AGmakonts/zf-oauth2.git"
+    "require-dev": {
+        "phpunit/phpunit": "^4.8 || ^5.0",
+        "squizlabs/php_codesniffer": "^2.3.1",
+        "zendframework/zend-session": "^2.7.3"
     },
-    {
-      "type": "vcs",
-      "url": "https://github.com/AGmakonts/zf-api-problem.git"
+    "autoload": {
+        "psr-4": {
+            "ZF\\MvcAuth\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "ZFTest\\MvcAuth\\": "test/"
+        }
+    },
+    "scripts": {
+        "check": [
+            "@cs-check",
+            "@test"
+        ],
+        "cs-check": "phpcs",
+        "cs-fix": "phpcbf",
+        "test": "phpunit"
     }
-  ],
-  "extra": {
-    "branch-alias": {
-      "dev-master": "1.3-dev",
-      "dev-develop": "1.4-dev"
-    }
-  },
-  "require": {
-    "zendframework/zend-authentication": "2.5.*",
-    "zendframework/zend-eventmanager": "3.0.*",
-    "zendframework/zend-http": "2.5.*",
-    "zendframework/zend-mvc": "3.0.*",
-    "zendframework/zend-permissions-acl": "2.6.*",
-    "zendframework/zend-permissions-rbac": "2.5.*",
-    "zendframework/zend-servicemanager": "3.1.*",
-    "zendframework/zend-stdlib": "3.0.*",
-    "zfcampus/zf-api-problem": "dev-feature/zf3-support",
-    "zfcampus/zf-content-negotiation": "dev-feature/zf3",
-    "zfcampus/zf-oauth2": "dev-feature/zf3"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "~4.7",
-    "squizlabs/php_codesniffer": "^2.3.1",
-    "zendframework/zend-loader": "~2.3",
-    "zendframework/zend-session": "~2.3"
-  },
-  "autoload": {
-    "psr-4": {
-      "ZF\\MvcAuth\\": "src/"
-    },
-    "classmap": [
-      "Module.php"
-    ]
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "ZFTest\\MvcAuth\\": "test/"
-    }
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         }
     },
     "require": {
+        "php": "^5.6 || ^7.0",
         "zendframework/zend-authentication": "^2.5.3",
         "zendframework/zend-eventmanager": "^2.6.3 || ^3.0.1",
         "zendframework/zend-http": "^2.5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,2877 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "3c97763a4fda38ea0fa49ee842679202",
+    "content-hash": "92444a8247ae9a965171e1c9d3f6ef47",
+    "packages": [
+        {
+            "name": "bshaffer/oauth2-server-php",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bshaffer/oauth2-server-php.git",
+                "reference": "058c98f73209f9c49495e1799d32c035196fe8b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bshaffer/oauth2-server-php/zipball/058c98f73209f9c49495e1799d32c035196fe8b8",
+                "reference": "058c98f73209f9c49495e1799d32c035196fe8b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "~2.8 is required to use the DynamoDB storage engine",
+                "firebase/php-jwt": "~2.2 is required to use JWT features",
+                "predis/predis": "Required to use the Redis storage engine",
+                "thobbs/phpcassa": "Required to use the Cassandra storage engine"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "OAuth2": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brent Shaffer",
+                    "email": "bshafs@gmail.com",
+                    "homepage": "http://brentertainment.com"
+                }
+            ],
+            "description": "OAuth2 Server for PHP",
+            "homepage": "http://github.com/bshaffer/oauth2-server-php",
+            "keywords": [
+                "auth",
+                "oauth",
+                "oauth2"
+            ],
+            "time": "2015-09-18 18:05:10"
+        },
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "time": "2014-12-30 15:22:37"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/088c04e2f261c33bed6ca5245491cfca69195ccf",
+                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2016-04-03 06:00:07"
+        },
+        {
+            "name": "zendframework/zend-authentication",
+            "version": "2.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-authentication.git",
+                "reference": "1422dec160eb769c719cad2229847fcbf20a1405"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-authentication/zipball/1422dec160eb769c719cad2229847fcbf20a1405",
+                "reference": "1422dec160eb769c719cad2229847fcbf20a1405",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-crypt": "^2.6",
+                "zendframework/zend-db": "^2.7",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-ldap": "^2.6",
+                "zendframework/zend-session": "^2.6.2",
+                "zendframework/zend-uri": "^2.5",
+                "zendframework/zend-validator": "^2.6"
+            },
+            "suggest": {
+                "zendframework/zend-crypt": "Zend\\Crypt component",
+                "zendframework/zend-db": "Zend\\Db component",
+                "zendframework/zend-http": "Zend\\Http component",
+                "zendframework/zend-ldap": "Zend\\Ldap component",
+                "zendframework/zend-session": "Zend\\Session component",
+                "zendframework/zend-uri": "Zend\\Uri component",
+                "zendframework/zend-validator": "Zend\\Validator component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Authentication\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides an API for authentication and includes concrete authentication adapters for common use case scenarios",
+            "homepage": "https://github.com/zendframework/zend-authentication",
+            "keywords": [
+                "Authentication",
+                "zf2"
+            ],
+            "time": "2016-02-28 15:02:34"
+        },
+        {
+            "name": "zendframework/zend-config",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-config.git",
+                "reference": "2920e877a9f6dca9fa8f6bd3b1ffc2e19bb1e30d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-config/zipball/2920e877a9f6dca9fa8f6bd3b1ffc2e19bb1e30d",
+                "reference": "2920e877a9f6dca9fa8f6bd3b1ffc2e19bb1e30d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-filter": "^2.6",
+                "zendframework/zend-i18n": "^2.5",
+                "zendframework/zend-json": "^2.6.1",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
+            },
+            "suggest": {
+                "zendframework/zend-filter": "Zend\\Filter component",
+                "zendframework/zend-i18n": "Zend\\I18n component",
+                "zendframework/zend-json": "Zend\\Json to use the Json reader or writer classes",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager for use with the Config Factory to retrieve reader and writer instances"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev",
+                    "dev-develop": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Config\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides a nested object property based user interface for accessing this configuration data within application code",
+            "homepage": "https://github.com/zendframework/zend-config",
+            "keywords": [
+                "config",
+                "zf2"
+            ],
+            "time": "2016-02-04 23:01:10"
+        },
+        {
+            "name": "zendframework/zend-crypt",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-crypt.git",
+                "reference": "ed348e3e87c945759d11edae5316125c3582bc72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-crypt/zipball/ed348e3e87c945759d11edae5316125c3582bc72",
+                "reference": "ed348e3e87c945759d11edae5316125c3582bc72",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "~1.0",
+                "ext-mbstring": "*",
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-math": "^3.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8",
+                "squizlabs/php_codesniffer": "^2.3.1"
+            },
+            "suggest": {
+                "ext-openssl": "Required for most features of Zend\\Crypt"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Crypt\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-crypt",
+            "keywords": [
+                "crypt",
+                "zf2"
+            ],
+            "time": "2016-06-21 18:15:32"
+        },
+        {
+            "name": "zendframework/zend-escaper",
+            "version": "2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-escaper.git",
+                "reference": "2dcd14b61a72d8b8e27d579c6344e12c26141d4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/2dcd14b61a72d8b8e27d579c6344e12c26141d4e",
+                "reference": "2dcd14b61a72d8b8e27d579c6344e12c26141d4e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-escaper",
+            "keywords": [
+                "escaper",
+                "zf2"
+            ],
+            "time": "2016-06-30 19:48:38"
+        },
+        {
+            "name": "zendframework/zend-eventmanager",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-eventmanager.git",
+                "reference": "5c80bdee0e952be112dcec0968bad770082c3a6e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/5c80bdee0e952be112dcec0968bad770082c3a6e",
+                "reference": "5c80bdee0e952be112dcec0968bad770082c3a6e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "^0.1",
+                "container-interop/container-interop": "^1.1.0",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "^2.0",
+                "zendframework/zend-stdlib": "^2.7.3 || ^3.0"
+            },
+            "suggest": {
+                "container-interop/container-interop": "^1.1.0, to use the lazy listeners feature",
+                "zendframework/zend-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://github.com/zendframework/zend-eventmanager",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "zf2"
+            ],
+            "time": "2016-02-18 20:53:00"
+        },
+        {
+            "name": "zendframework/zend-filter",
+            "version": "2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-filter.git",
+                "reference": "84c50246428efb0a1e52868e162dab3e149d5b80"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-filter/zipball/84c50246428efb0a1e52868e162dab3e149d5b80",
+                "reference": "84c50246428efb0a1e52868e162dab3e149d5b80",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "pear/archive_tar": "^1.4",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-crypt": "^2.6",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-uri": "^2.5"
+            },
+            "suggest": {
+                "zendframework/zend-crypt": "Zend\\Crypt component, for encryption filters",
+                "zendframework/zend-i18n": "Zend\\I18n component for filters depending on i18n functionality",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component, for using the filter chain functionality",
+                "zendframework/zend-uri": "Zend\\Uri component, for the UriNormalize filter"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev",
+                    "dev-develop": "2.8-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Filter",
+                    "config-provider": "Zend\\Filter\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Filter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides a set of commonly needed data filters",
+            "homepage": "https://github.com/zendframework/zend-filter",
+            "keywords": [
+                "filter",
+                "zf2"
+            ],
+            "time": "2016-04-18 18:32:43"
+        },
+        {
+            "name": "zendframework/zend-http",
+            "version": "2.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-http.git",
+                "reference": "7b920b4ec34b5ee58f76eb4e8c408b083121953c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/7b920b4ec34b5ee58f76eb4e8c408b083121953c",
+                "reference": "7b920b4ec34b5ee58f76eb4e8c408b083121953c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-loader": "^2.5",
+                "zendframework/zend-stdlib": "^2.5 || ^3.0",
+                "zendframework/zend-uri": "^2.5",
+                "zendframework/zend-validator": "^2.5"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "^4.0",
+                "zendframework/zend-config": "^2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Http\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
+            "homepage": "https://github.com/zendframework/zend-http",
+            "keywords": [
+                "http",
+                "zf2"
+            ],
+            "time": "2016-02-04 20:36:48"
+        },
+        {
+            "name": "zendframework/zend-json",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-json.git",
+                "reference": "f42a1588e75c2a3e338cd94c37906231e616daab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-json/zipball/f42a1588e75c2a3e338cd94c37906231e616daab",
+                "reference": "f42a1588e75c2a3e338cd94c37906231e616daab",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "^2.3",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "suggest": {
+                "zendframework/zend-json-server": "For implementing JSON-RPC servers",
+                "zendframework/zend-xml2json": "For converting XML documents to JSON"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Json\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides convenience methods for serializing native PHP to JSON and decoding JSON to native PHP",
+            "homepage": "https://github.com/zendframework/zend-json",
+            "keywords": [
+                "json",
+                "zf2"
+            ],
+            "time": "2016-04-01 02:34:00"
+        },
+        {
+            "name": "zendframework/zend-loader",
+            "version": "2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-loader.git",
+                "reference": "c5fd2f071bde071f4363def7dea8dec7393e135c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-loader/zipball/c5fd2f071bde071f4363def7dea8dec7393e135c",
+                "reference": "c5fd2f071bde071f4363def7dea8dec7393e135c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.23"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Loader\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-loader",
+            "keywords": [
+                "loader",
+                "zf2"
+            ],
+            "time": "2015-06-03 14:05:47"
+        },
+        {
+            "name": "zendframework/zend-math",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-math.git",
+                "reference": "fda3b4e6c3bb15c35adc6db38b2eacabaa243e65"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-math/zipball/fda3b4e6c3bb15c35adc6db38b2eacabaa243e65",
+                "reference": "fda3b4e6c3bb15c35adc6db38b2eacabaa243e65",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "paragonie/random_compat": "^2.0.2",
+                "php": "^5.5 || ^7.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-bcmath": "If using the bcmath functionality",
+                "ext-gmp": "If using the gmp functionality"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Math\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-math",
+            "keywords": [
+                "math",
+                "zf2"
+            ],
+            "time": "2016-04-28 17:37:42"
+        },
+        {
+            "name": "zendframework/zend-modulemanager",
+            "version": "2.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-modulemanager.git",
+                "reference": "2a59ab9a0dd7699a55050dff659ab0f28272b46e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-modulemanager/zipball/2a59ab9a0dd7699a55050dff659ab0f28272b46e",
+                "reference": "2a59ab9a0dd7699a55050dff659ab0f28272b46e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-config": "^2.6",
+                "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-console": "^2.6",
+                "zendframework/zend-di": "^2.6",
+                "zendframework/zend-loader": "^2.5",
+                "zendframework/zend-mvc": "^2.7",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
+            },
+            "suggest": {
+                "zendframework/zend-config": "Zend\\Config component",
+                "zendframework/zend-console": "Zend\\Console component",
+                "zendframework/zend-loader": "Zend\\Loader component",
+                "zendframework/zend-mvc": "Zend\\Mvc component",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev",
+                    "dev-develop": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\ModuleManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-modulemanager",
+            "keywords": [
+                "modulemanager",
+                "zf2"
+            ],
+            "time": "2016-05-16 21:21:11"
+        },
+        {
+            "name": "zendframework/zend-mvc",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-mvc.git",
+                "reference": "3c6c9e570e01a8b8fcb0605d2f8eb25812c0c273"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-mvc/zipball/3c6c9e570e01a8b8fcb0605d2f8eb25812c0c273",
+                "reference": "3c6c9e570e01a8b8fcb0605d2f8eb25812c0c273",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-eventmanager": "^3.0",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-modulemanager": "^2.7.1",
+                "zendframework/zend-router": "^3.0.1",
+                "zendframework/zend-servicemanager": "^3.0.3",
+                "zendframework/zend-stdlib": "^3.0",
+                "zendframework/zend-view": "^2.6.7"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "^4.5",
+                "zendframework/zend-json": "^2.6.1 || ^3.0",
+                "zendframework/zend-psr7bridge": "^0.2"
+            },
+            "suggest": {
+                "zendframework/zend-json": "(^2.6.1 || ^3.0) To auto-deserialize JSON body content in AbstractRestfulController extensions, when json_decode is unavailable",
+                "zendframework/zend-mvc-console": "zend-mvc-console provides the ability to expose zend-mvc as a console application",
+                "zendframework/zend-mvc-i18n": "zend-mvc-i18n provides integration with zend-i18n, including a translation bridge and translatable route segments",
+                "zendframework/zend-mvc-plugin-fileprg": "To provide Post/Redirect/Get functionality around forms that container file uploads",
+                "zendframework/zend-mvc-plugin-flashmessenger": "To provide flash messaging capabilities between requests",
+                "zendframework/zend-mvc-plugin-identity": "To access the authenticated identity (per zend-authentication) in controllers",
+                "zendframework/zend-mvc-plugin-prg": "To provide Post/Redirect/Get functionality within controllers",
+                "zendframework/zend-psr7bridge": "(^0.2) To consume PSR-7 middleware within the MVC workflow",
+                "zendframework/zend-servicemanager-di": "zend-servicemanager-di provides utilities for integrating zend-di and zend-servicemanager in your zend-mvc application"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Mvc\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-mvc",
+            "keywords": [
+                "mvc",
+                "zf2"
+            ],
+            "time": "2016-06-30 20:30:28"
+        },
+        {
+            "name": "zendframework/zend-permissions-acl",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-permissions-acl.git",
+                "reference": "843bbd9c6f6d20b84dd0ce6c815d10397e98082b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-permissions-acl/zipball/843bbd9c6f6d20b84dd0ce6c815d10397e98082b",
+                "reference": "843bbd9c6f6d20b84dd0ce6c815d10397e98082b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
+            },
+            "suggest": {
+                "zendframework/zend-servicemanager": "To support Zend\\Permissions\\Acl\\Assertion\\AssertionManager plugin manager usage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev",
+                    "dev-develop": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Permissions\\Acl\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides a lightweight and flexible access control list (ACL) implementation for privileges management",
+            "homepage": "https://github.com/zendframework/zend-permissions-acl",
+            "keywords": [
+                "acl",
+                "zf2"
+            ],
+            "time": "2016-02-03 21:46:45"
+        },
+        {
+            "name": "zendframework/zend-permissions-rbac",
+            "version": "2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-permissions-rbac.git",
+                "reference": "4213a4889ae7d7607c7974124965d12d1c395115"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-permissions-rbac/zipball/4213a4889ae7d7607c7974124965d12d1c395115",
+                "reference": "4213a4889ae7d7607c7974124965d12d1c395115",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.23"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Permissions\\Rbac\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides a role-based access control management",
+            "homepage": "https://github.com/zendframework/zend-permissions-rbac",
+            "keywords": [
+                "rbac",
+                "zf2"
+            ],
+            "time": "2015-06-03 14:05:54"
+        },
+        {
+            "name": "zendframework/zend-router",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-router.git",
+                "reference": "03763610632a9022aff22a0e8f340852e68392a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-router/zipball/03763610632a9022aff22a0e8f340852e68392a1",
+                "reference": "03763610632a9022aff22a0e8f340852e68392a1",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-http": "^2.5",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-stdlib": "^2.7.5 || ^3.0"
+            },
+            "conflict": {
+                "zendframework/zend-mvc": "<3.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5",
+                "sebastian/version": "^1.0.4",
+                "squizlabs/php_codesniffer": "^2.3",
+                "zendframework/zend-i18n": "^2.6"
+            },
+            "suggest": {
+                "zendframework/zend-i18n": "^2.6, if defining translatable HTTP path segments"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Router",
+                    "config-provider": "Zend\\Router\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Router\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-router",
+            "keywords": [
+                "mvc",
+                "routing",
+                "zf2"
+            ],
+            "time": "2016-05-31 20:47:48"
+        },
+        {
+            "name": "zendframework/zend-servicemanager",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-servicemanager.git",
+                "reference": "90b88339a4b937c6bb0055ee04b2567e7e628f25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/90b88339a4b937c6bb0055ee04b2567e7e628f25",
+                "reference": "90b88339a4b937c6bb0055ee04b2567e7e628f25",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "~1.0",
+                "php": "^5.5 || ^7.0"
+            },
+            "provide": {
+                "container-interop/container-interop-implementation": "^1.1"
+            },
+            "require-dev": {
+                "ocramius/proxy-manager": "^1.0 || ^2.0",
+                "phpbench/phpbench": "^0.10.0",
+                "phpunit/phpunit": "^4.6 || ^5.2.10",
+                "squizlabs/php_codesniffer": "^2.5.1"
+            },
+            "suggest": {
+                "ocramius/proxy-manager": "ProxyManager 1.* to handle lazy initialization of services",
+                "zendframework/zend-stdlib": "zend-stdlib ^2.5 if you wish to use the MergeReplaceKey or MergeRemoveKey features in Config instances"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-servicemanager",
+            "keywords": [
+                "service-manager",
+                "servicemanager",
+                "zf"
+            ],
+            "time": "2016-06-01 16:50:58"
+        },
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "8bafa58574204bdff03c275d1d618aaa601588ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/8bafa58574204bdff03c275d1d618aaa601588ae",
+                "reference": "8bafa58574204bdff03c275d1d618aaa601588ae",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1",
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-stdlib",
+            "keywords": [
+                "stdlib",
+                "zf2"
+            ],
+            "time": "2016-04-12 21:19:36"
+        },
+        {
+            "name": "zendframework/zend-uri",
+            "version": "2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-uri.git",
+                "reference": "0bf717a239432b1a1675ae314f7c4acd742749ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-uri/zipball/0bf717a239432b1a1675ae314f7c4acd742749ed",
+                "reference": "0bf717a239432b1a1675ae314f7c4acd742749ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-escaper": "^2.5",
+                "zendframework/zend-validator": "^2.5"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "a component that aids in manipulating and validating » Uniform Resource Identifiers (URIs)",
+            "homepage": "https://github.com/zendframework/zend-uri",
+            "keywords": [
+                "uri",
+                "zf2"
+            ],
+            "time": "2016-02-17 22:38:51"
+        },
+        {
+            "name": "zendframework/zend-validator",
+            "version": "2.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-validator.git",
+                "reference": "8ec9f57a717dd37340308aa632f148a2c2be1cfc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/8ec9f57a717dd37340308aa632f148a2c2be1cfc",
+                "reference": "8ec9f57a717dd37340308aa632f148a2c2be1cfc",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "^4.0",
+                "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-config": "^2.6",
+                "zendframework/zend-db": "^2.7",
+                "zendframework/zend-filter": "^2.6",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-i18n": "^2.6",
+                "zendframework/zend-math": "^2.6",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-session": "^2.6.2",
+                "zendframework/zend-uri": "^2.5"
+            },
+            "suggest": {
+                "zendframework/zend-db": "Zend\\Db component",
+                "zendframework/zend-filter": "Zend\\Filter component, required by the Digits validator",
+                "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages as well as to use the various Date validators",
+                "zendframework/zend-i18n-resources": "Translations of validator messages",
+                "zendframework/zend-math": "Zend\\Math component",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
+                "zendframework/zend-session": "Zend\\Session component",
+                "zendframework/zend-uri": "Zend\\Uri component, required by the Uri and Sitemap\\Loc validators"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev",
+                    "dev-develop": "2.9-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Validator",
+                    "config-provider": "Zend\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides a set of commonly needed validators",
+            "homepage": "https://github.com/zendframework/zend-validator",
+            "keywords": [
+                "validator",
+                "zf2"
+            ],
+            "time": "2016-06-23 13:44:31"
+        },
+        {
+            "name": "zendframework/zend-view",
+            "version": "2.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-view.git",
+                "reference": "71b4ebd0c4c9a2d0e0438f9d3a435e08dd769ff8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-view/zipball/71b4ebd0c4c9a2d0e0438f9d3a435e08dd769ff8",
+                "reference": "71b4ebd0c4c9a2d0e0438f9d3a435e08dd769ff8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
+                "zendframework/zend-loader": "^2.5",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "^4.5",
+                "zendframework/zend-authentication": "^2.5",
+                "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-config": "^2.6",
+                "zendframework/zend-console": "^2.6",
+                "zendframework/zend-escaper": "^2.5",
+                "zendframework/zend-feed": "^2.7",
+                "zendframework/zend-filter": "^2.6.1",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-i18n": "^2.6",
+                "zendframework/zend-json": "^2.6.1",
+                "zendframework/zend-log": "^2.7",
+                "zendframework/zend-modulemanager": "^2.7.1",
+                "zendframework/zend-mvc": "^2.7 || ^3.0",
+                "zendframework/zend-navigation": "^2.5",
+                "zendframework/zend-paginator": "^2.5",
+                "zendframework/zend-permissions-acl": "^2.6",
+                "zendframework/zend-router": "^3.0.1",
+                "zendframework/zend-serializer": "^2.6.1",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-session": "^2.6.2",
+                "zendframework/zend-uri": "^2.5"
+            },
+            "suggest": {
+                "zendframework/zend-authentication": "Zend\\Authentication component",
+                "zendframework/zend-escaper": "Zend\\Escaper component",
+                "zendframework/zend-feed": "Zend\\Feed component",
+                "zendframework/zend-filter": "Zend\\Filter component",
+                "zendframework/zend-http": "Zend\\Http component",
+                "zendframework/zend-i18n": "Zend\\I18n component",
+                "zendframework/zend-json": "Zend\\Json component",
+                "zendframework/zend-mvc": "Zend\\Mvc component",
+                "zendframework/zend-navigation": "Zend\\Navigation component",
+                "zendframework/zend-paginator": "Zend\\Paginator component",
+                "zendframework/zend-permissions-acl": "Zend\\Permissions\\Acl component",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component",
+                "zendframework/zend-uri": "Zend\\Uri component"
+            },
+            "bin": [
+                "bin/templatemap_generator.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev",
+                    "dev-develop": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\View\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides a system of helpers, output filters, and variable escaping",
+            "homepage": "https://github.com/zendframework/zend-view",
+            "keywords": [
+                "view",
+                "zf2"
+            ],
+            "time": "2016-06-30 22:28:07"
+        },
+        {
+            "name": "zfcampus/zf-api-problem",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zfcampus/zf-api-problem.git",
+                "reference": "3d2cb9f91aace74d4ca00d865d1ed95b593c6187"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zfcampus/zf-api-problem/zipball/3d2cb9f91aace74d4ca00d865d1ed95b593c6187",
+                "reference": "3d2cb9f91aace74d4ca00d865d1ed95b593c6187",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-eventmanager": "^2.6.3 || ^3.0.1",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-json": "^2.6.1 || ^3.0",
+                "zendframework/zend-mvc": "^2.7.9 || ^3.0.2",
+                "zendframework/zend-view": "^2.8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8",
+                "squizlabs/php_codesniffer": "^2.3.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev",
+                    "dev-develop": "1.3-dev"
+                },
+                "zf": {
+                    "module": "ZF\\ApiProblem"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ZF\\ApiProblem\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "ZF2 Module providing API-Problem assets and rendering",
+            "homepage": "http://apigility.org/",
+            "keywords": [
+                "api-problem",
+                "module",
+                "rest",
+                "zend",
+                "zf2"
+            ],
+            "time": "2016-07-07 13:52:00"
+        },
+        {
+            "name": "zfcampus/zf-content-negotiation",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zfcampus/zf-content-negotiation.git",
+                "reference": "2f7c52af7ef7517509eb7fe9404a54bdc9944829"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zfcampus/zf-content-negotiation/zipball/2f7c52af7ef7517509eb7fe9404a54bdc9944829",
+                "reference": "2f7c52af7ef7517509eb7fe9404a54bdc9944829",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-eventmanager": "^2.6.3 || ^3.0.1",
+                "zendframework/zend-filter": "^2.7.1",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-json": "^2.6.1 || ^3.0",
+                "zendframework/zend-mvc": "^2.7.9 || ^3.0.2",
+                "zendframework/zend-servicemanager": "^2.7.6 || ^3.1",
+                "zendframework/zend-stdlib": "^2.7.7 || ^3.0.1",
+                "zendframework/zend-validator": "^2.8.1",
+                "zendframework/zend-view": "^2.8.1",
+                "zfcampus/zf-api-problem": "^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8",
+                "squizlabs/php_codesniffer": "^2.3.1",
+                "zfcampus/zf-hal": "^1.4"
+            },
+            "suggest": {
+                "zendframework/zend-console": "^2.3, if you intend to use the RequestFactory"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev",
+                    "dev-develop": "1.3-dev"
+                },
+                "zf": {
+                    "module": "ZF\\ContentNegotiation"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ZF\\ContentNegotiation\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "ZF2 Module providing content-negotiation features",
+            "homepage": "http://apigility.org/",
+            "keywords": [
+                "content-negotiation",
+                "module",
+                "zend",
+                "zf2"
+            ],
+            "time": "2016-07-07 21:13:40"
+        },
+        {
+            "name": "zfcampus/zf-oauth2",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zfcampus/zf-oauth2.git",
+                "reference": "55ab3e4242d6a53a158cf1a1edd04f35866b0ac4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zfcampus/zf-oauth2/zipball/55ab3e4242d6a53a158cf1a1edd04f35866b0ac4",
+                "reference": "55ab3e4242d6a53a158cf1a1edd04f35866b0ac4",
+                "shasum": ""
+            },
+            "require": {
+                "bshaffer/oauth2-server-php": "^1.8",
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-crypt": "^2.6 || ^3.0",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-mvc": "^2.7.9 || ^3.0.2",
+                "zendframework/zend-servicemanager": "^2.7.6 || ^3.1",
+                "zfcampus/zf-api-problem": "^1.2.1",
+                "zfcampus/zf-content-negotiation": "^1.2.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9",
+                "phpunit/phpunit": "^4.8 || ^5.4",
+                "squizlabs/php_codesniffer": "^2.3.1",
+                "zendframework/zend-authentication": "^2.5.3",
+                "zendframework/zend-db": "^2.8.1",
+                "zendframework/zend-i18n": "^2.7.3",
+                "zendframework/zend-log": "^2.9",
+                "zendframework/zend-modulemanager": "^2.7.2",
+                "zendframework/zend-serializer": "^2.8",
+                "zendframework/zend-test": "^2.6.1 || ^3.0.1"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "^1.0.5, if you are using ext/mongodb and wish to use the MongoAdapter for OAuth2 credential storage."
+            },
+            "bin": [
+                "bin/bcrypt.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev",
+                    "dev-develop": "1.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ZF\\OAuth2\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "ZF2 module for implementing an OAuth2 server",
+            "keywords": [
+                "api",
+                "framework",
+                "oauth2",
+                "zf2"
+            ],
+            "time": "2016-07-10 23:11:53"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "a8773992b362b58498eed24bf85005f363c34771"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/a8773992b362b58498eed24bf85005f363c34771",
+                "reference": "a8773992b362b58498eed24bf85005f363c34771",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2015-11-20 12:04:31"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2015-12-27 11:43:31"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9270140b940ff02e58ec577c237274e92cd40cdd",
+                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.2.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2016-06-10 09:48:41"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2016-06-10 07:14:17"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
+                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1",
+                "sebastian/recursion-context": "^1.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2016-06-07 08:13:47"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "900370c81280cc0d942ffbc5912d80464eaee7e9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/900370c81280cc0d942ffbc5912d80464eaee7e9",
+                "reference": "900370c81280cc0d942ffbc5912d80464eaee7e9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "^1.4.2",
+                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "sebastian/environment": "^1.3.2",
+                "sebastian/version": "~1.0|~2.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "^5.4"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.4.0",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2016-06-03 05:03:56"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2015-06-21 13:08:43"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21 13:50:34"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2016-05-12 18:03:57"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2015-09-15 10:49:45"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "5.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "2f1fc94b77ea6418bd6a06c64a1dac0645fbce59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2f1fc94b77ea6418bd6a06c64a1dac0645fbce59",
+                "reference": "2f1fc94b77ea6418bd6a06c64a1dac0645fbce59",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.3.1",
+                "phpunit/php-code-coverage": "^4.0",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "^1.0.6",
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "~1.1",
+                "sebastian/diff": "~1.2",
+                "sebastian/environment": "^1.3 || ^2.0",
+                "sebastian/exporter": "~1.2",
+                "sebastian/global-state": "~1.0",
+                "sebastian/object-enumerator": "~1.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "~1.0|~2.0",
+                "symfony/yaml": "~2.1|~3.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "suggest": {
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2016-06-16 06:01:15"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "b13d0d9426ced06958bd32104653526a6c998a52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/b13d0d9426ced06958bd32104653526a6c998a52",
+                "reference": "b13d0d9426ced06958bd32104653526a6c998a52",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.4"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2016-06-12 07:37:26"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2016-02-13 06:45:14"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2015-07-26 15:48:44"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2015-12-08 07:14:41"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "1.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2016-05-17 03:18:57"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2016-06-17 09:04:28"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2015-10-12 03:26:01"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2016-01-28 13:25:10"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2015-11-11 19:50:13"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28 20:34:47"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-02-04 12:56:52"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
+                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2016-05-30 22:24:32"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "2884c26ce4c1d61aebf423a8b912950fe7c764de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/2884c26ce4c1d61aebf423a8b912950fe7c764de",
+                "reference": "2884c26ce4c1d61aebf423a8b912950fe7c764de",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 05:41:56"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde",
+                "reference": "30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2015-08-24 13:29:44"
+        },
+        {
+            "name": "zendframework/zend-session",
+            "version": "2.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-session.git",
+                "reference": "346e9709657b81a5d53d70ce754730a26d1f02f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-session/zipball/346e9709657b81a5d53d70ce754730a26d1f02f2",
+                "reference": "346e9709657b81a5d53d70ce754730a26d1f02f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "container-interop/container-interop": "^1.1",
+                "fabpot/php-cs-fixer": "1.7.*",
+                "mongodb/mongodb": "^1.0.1",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-db": "^2.7",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-validator": "^2.6"
+            },
+            "suggest": {
+                "mongodb/mongodb": "If you want to use the MongoDB session save handler",
+                "zendframework/zend-cache": "Zend\\Cache component",
+                "zendframework/zend-db": "Zend\\Db component",
+                "zendframework/zend-http": "Zend\\Http component",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component",
+                "zendframework/zend-validator": "Zend\\Validator component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev",
+                    "dev-develop": "2.8-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Session",
+                    "config-provider": "Zend\\Session\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Session\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "manage and preserve session data, a logical complement of cookie data, across multiple page requests by the same client",
+            "homepage": "https://github.com/zendframework/zend-session",
+            "keywords": [
+                "session",
+                "zf2"
+            ],
+            "time": "2016-07-05 18:32:50"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,44 +1,52 @@
-<?php // @codingStandardsIgnoreFile
+<?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
  * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
  */
+
+namespace ZF\MvcAuth;
 
 use Zend\Authentication\Storage\NonPersistent;
 use Zend\ServiceManager\Factory\InvokableFactory;
 
 return [
     'controller_plugins' => [
-        'invokables' => [
-            'getidentity' => 'ZF\MvcAuth\Identity\IdentityPlugin',
+        'aliases' => [
+            'getidentity' => Identity\IdentityPlugin::class,
+            'getIdentity' => Identity\IdentityPlugin::class,
+        ],
+        'factories' => [
+            Identity\IdentityPlugin::class => InvokableFactory::class,
         ],
     ],
     'service_manager'    => [
         'aliases'    => [
-            'authentication'                                  => 'ZF\MvcAuth\Authentication',
-            'authorization'                                   => 'ZF\MvcAuth\Authorization\AuthorizationInterface',
-            'ZF\MvcAuth\Authorization\AuthorizationInterface' => 'ZF\MvcAuth\Authorization\AclAuthorization',
+            'authentication'                            => 'ZF\MvcAuth\Authentication',
+            'authorization'                             => Authorization\AuthorizationInterface::class,
+            Authorization\AuthorizationInterface::class => Authorization\AclAuthorization::class,
         ],
         'delegators' => [
-            'ZF\MvcAuth\Authentication\DefaultAuthenticationListener' => [
-                'ZF\MvcAuth\Factory\AuthenticationAdapterDelegatorFactory',
+            Authentication\DefaultAuthenticationListener::class => [
+                Factory\AuthenticationAdapterDelegatorFactory::class,
             ],
         ],
+        // @codingStandardsIgnoreStart
         'factories'  => [
-            'ZF\MvcAuth\Authentication'                                   => 'ZF\MvcAuth\Factory\AuthenticationServiceFactory',
-            'ZF\MvcAuth\ApacheResolver'                                   => 'ZF\MvcAuth\Factory\ApacheResolverFactory',
-            'ZF\MvcAuth\FileResolver'                                     => 'ZF\MvcAuth\Factory\FileResolverFactory',
-            'ZF\MvcAuth\Authentication\DefaultAuthenticationListener'     => 'ZF\MvcAuth\Factory\DefaultAuthenticationListenerFactory',
-            'ZF\MvcAuth\Authentication\AuthHttpAdapter'                   => 'ZF\MvcAuth\Factory\DefaultAuthHttpAdapterFactory',
-            'ZF\MvcAuth\Authorization\AclAuthorization'                   => 'ZF\MvcAuth\Factory\AclAuthorizationFactory',
-            'ZF\MvcAuth\Authorization\DefaultAuthorizationListener'       => 'ZF\MvcAuth\Factory\DefaultAuthorizationListenerFactory',
-            'ZF\MvcAuth\Authorization\DefaultResourceResolverListener'    => 'ZF\MvcAuth\Factory\DefaultResourceResolverListenerFactory',
-            'ZF\OAuth2\Service\OAuth2Server'                              => 'ZF\MvcAuth\Factory\NamedOAuth2ServerFactory',
-            NonPersistent::class                                          => InvokableFactory::class,
-            'ZF\MvcAuth\Authentication\DefaultAuthenticationPostListener' => InvokableFactory::class,
-            'ZF\MvcAuth\Authorization\DefaultAuthorizationPostListener'   => InvokableFactory::class,
+            'ZF\MvcAuth\Authentication'                             => Factory\AuthenticationServiceFactory::class,
+            'ZF\MvcAuth\ApacheResolver'                             => Factory\ApacheResolverFactory::class,
+            'ZF\MvcAuth\FileResolver'                               => Factory\FileResolverFactory::class,
+            Authentication\DefaultAuthenticationListener::class     => Factory\DefaultAuthenticationListenerFactory::class,
+            Authentication\AuthHttpAdapter::class                   => Factory\DefaultAuthHttpAdapterFactory::class,
+            Authorization\AclAuthorization::class                   => Factory\AclAuthorizationFactory::class,
+            Authorization\DefaultAuthorizationListener::class       => Factory\DefaultAuthorizationListenerFactory::class,
+            Authorization\DefaultResourceResolverListener::class    => Factory\DefaultResourceResolverListenerFactory::class,
+            'ZF\OAuth2\Service\OAuth2Server'                        => Factory\NamedOAuth2ServerFactory::class,
+            NonPersistent::class                                    => InvokableFactory::class,
+            Authentication\DefaultAuthenticationPostListener::class => InvokableFactory::class,
+            Authorization\DefaultAuthorizationPostListener::class   => InvokableFactory::class,
 
         ],
+        // @codingStandardsIgnoreEnd
     ],
     'zf-mvc-auth'        => [
         'authentication' => [
@@ -49,16 +57,20 @@ return [
              *
              * Note: as of 1.1, these are deprecated.
              *
-            'http' => array(
-                'accept_schemes' => array('basic', 'digest'),
+            'http' => [
+                'accept_schemes' => ['basic', 'digest'],
                 'realm' => 'My Web Site',
                 'digest_domains' => '/',
                 'nonce_timeout' => 3600,
-                'htpasswd' => APPLICATION_PATH . '/data/htpasswd' // htpasswd tool generated
-                'htdigest' => APPLICATION_PATH . '/data/htdigest' // @see http://www.askapache.com/online-tools/htpasswd-generator/
-                'basic_resolver_factory' => 'ServiceManagerKeyToAsk', // if this is set, the htpasswd key is ignored - see below
-                'digest_resolver_factory' => 'ServiceManagerKeyToAsk', // if this is set, the htdigest key is ignored - see below
-            ),
+                // htpasswd tool generated:
+                'htpasswd' => APPLICATION_PATH . '/data/htpasswd',
+                // @see http://www.askapache.com/online-tools/htpasswd-generator/
+                'htdigest' => APPLICATION_PATH . '/data/htdigest',
+                // If this is set, the htpasswd key is ignored - see below
+                'basic_resolver_factory' => 'ServiceManagerKeyToAsk',
+                // If this is set, the htdigest key is ignored - see below:
+                'digest_resolver_factory' => 'ServiceManagerKeyToAsk',
+            ],
              *
              * Starting in 1.1, we have an "adapters" key, which is a key/value
              * pair of adapter name -> adapter configuration information. Each
@@ -100,86 +112,88 @@ return [
              *
              * This looks like the following for the HTTP basic/digest and OAuth2
              * adapters:
-            'adapters' => array
+            'adapters' => [
                 // HTTP adapter
-                'api' => array(
+                'api' => [
                     'adapter' => 'ZF\MvcAuth\Authentication\HttpAdapter',
-                    'options' => array(
-                        'accept_schemes' => array('basic', 'digest'),
+                    'options' => [
+                        'accept_schemes' => ['basic', 'digest'],
                         'realm' => 'api',
                         'digest_domains' => 'https://example.com',
                         'nonce_timeout' => 3600,
                         'htpasswd' => 'data/htpasswd',
                         'htdigest' => 'data/htdigest',
-                        'basic_resolver_factory' => 'ServiceManagerKeyToAsk', // if this is set, the htpasswd key is ignored
-                        'digest_resolver_factory' => 'ServiceManagerKeyToAsk', // if this is set, the htdigest key is ignored
-                    ),
-                ),
+                        // If this is set, the htpasswd key is ignored:
+                        'basic_resolver_factory' => 'ServiceManagerKeyToAsk',
+                        // If this is set, the htdigest key is ignored:
+                        'digest_resolver_factory' => 'ServiceManagerKeyToAsk',
+                    ],
+                ],
                 // OAuth2 adapter, using an "adapter" type of "pdo"
-                'user' => array(
+                'user' => [
                     'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
-                    'storage' => array(
+                    'storage' => [
                         'adapter' => 'pdo',
                         'route' => '/user',
                         'dsn' => 'mysql:host=localhost;dbname=oauth2',
                         'username' => 'username',
                         'password' => 'password',
-                        'options' => aray(
+                        'options' => [
                             1002 => 'SET NAMES utf8', // PDO::MYSQL_ATTR_INIT_COMMAND
-                        ),
-                    ),
-                ),
+                        ],
+                    ],
+                ],
                 // OAuth2 adapter, using an "adapter" type of "mongo"
-                'client' => array(
+                'client' => [
                     'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
-                    'storage' => array(
+                    'storage' => [
                         'adapter' => 'mongo',
                         'route' => '/client',
                         'locator_name' => 'SomeServiceName', // If provided, pulls the given service
                         'dsn' => 'mongodb://localhost',
                         'database' => 'oauth2',
-                        'options' => array(
+                        'options' => [
                             'username' => 'username',
                             'password' => 'password',
                             'connectTimeoutMS' => 500,
-                        ),
-                    ),
-                ),
+                        ],
+                    ],
+                ],
                 // OAuth2 adapter, using a named "storage" service
-                'named-storage' => array(
+                'named-storage' => [
                     'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
-                    'storage' => array(
+                    'storage' => [
                         'storage' => 'Name\Of\An\OAuth2\Storage\Service',
                         'route' => '/named-storage',
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
              *
              * Next, we also have a "map", which maps an API module (with
              * optional version) to a given authentication type (one of basic,
              * digest, or oauth2):
-            'map' => array(
+            'map' => [
                 'ApiModuleName' => 'oauth2',
                 'OtherApi\V2' => 'basic',
                 'AnotherApi\V1' => 'digest',
-            ),
+            ],
              *
              * We also allow you to specify custom authentication types that you
              * support via listeners; by adding them to the configuration, you
              * ensure that they will be available for mapping modules to
              * authentication types in the Admin.
-            'types' => array(
+            'types' => [
                 'token',
                 'key',
                 'etc',
-            )
+            ]
              */
         ],
         'authorization'  => [
             // Toggle the following to true to change the ACL creation to
             // require an authenticated user by default, and thus selectively
             // allow unauthenticated users based on the rules.
-            'deny_by_default' => FALSE,
+            'deny_by_default' => false,
 
             /*
              * Rules indicating what controllers are behind authentication.
@@ -198,28 +212,28 @@ return [
              * special key "default" can be used to set the default flag for
              * all HTTP methods.
              *
-            'Controller\Service\Name' => array(
-                'actions' => array(
-                    'action' => array(
+            'Controller\Service\Name' => [
+                'actions' => [
+                    'action' => [
                         'default' => boolean,
                         'GET' => boolean,
                         'POST' => boolean,
                         // etc.
-                    ),
-                ),
-                'collection' => array(
+                    ],
+                ],
+                'collection' => [
                     'default' => boolean,
                     'GET' => boolean,
                     'POST' => boolean,
                     // etc.
-                ),
-                'entity' => array(
+                ],
+                'entity' => [
                     'default' => boolean,
                     'GET' => boolean,
                     'POST' => boolean,
                     // etc.
-                ),
-            ),
+                ],
+            ],
              */
         ],
     ],

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,6 +16,7 @@
     </rule>
 
     <!-- Paths to check -->
+    <file>config</file>
     <file>src</file>
     <file>test</file>
 </ruleset>

--- a/src/Authentication/DefaultAuthenticationListener.php
+++ b/src/Authentication/DefaultAuthenticationListener.php
@@ -1,17 +1,19 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\MvcAuth\Authentication;
 
+use InvalidArgumentException;
 use OAuth2\Server as OAuth2Server;
 use RuntimeException;
 use Zend\Authentication\Adapter\Http as HttpAuth;
-use Zend\Router\RouteMatch;
 use Zend\Http\Request as HttpRequest;
 use Zend\Http\Response as HttpResponse;
+use Zend\Mvc\Router\RouteMatch as V2RouteMatch;
+use Zend\Router\RouteMatch;
 use ZF\MvcAuth\Identity;
 use ZF\MvcAuth\MvcAuthEvent;
 
@@ -203,13 +205,23 @@ class DefaultAuthenticationListener
      * Match the controller to an authentication type, based on the API to
      * which the controller belongs.
      *
-     * @param null|RouteMatch $routeMatch
+     * @param null|V2RouteMatch|RouteMatch $routeMatch
      * @return string|false
      */
-    private function getTypeFromMap(RouteMatch $routeMatch = null)
+    private function getTypeFromMap($routeMatch = null)
     {
-        if (! $routeMatch) {
+        if (null === $routeMatch) {
             return false;
+        }
+
+        if (! ($routeMatch instanceof RouteMatch || $routeMatch instanceof V2RouteMatch)) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expected either a %s or %s; received %s',
+                __METHOD__,
+                RouteMatch::class,
+                V2RouteMatch::class,
+                (is_object($routeMatch) ? get_class($routeMatch) : gettype($routeMatch))
+            ));
         }
 
         $controller = $routeMatch->getParam('controller', false);

--- a/src/Authorization/AclAuthorizationFactory.php
+++ b/src/Authorization/AclAuthorizationFactory.php
@@ -1,13 +1,19 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\MvcAuth\Authorization;
 
 abstract class AclAuthorizationFactory
 {
+    /**
+     * Create and return an AclAuthorization instance populated with provided privileges.
+     *
+     * @param array $config
+     * @return AclAuthoriazation
+     */
     public static function factory(array $config)
     {
         // Determine whether we are whitelisting or blacklisting
@@ -28,26 +34,56 @@ abstract class AclAuthorizationFactory
             $grant = 'allow';
         }
 
-        foreach ($config as $set) {
+        if (! empty($config)) {
+            return self::injectGrants($acl, $grant, $config);
+        }
+
+        return $acl;
+    }
+
+    /**
+     * Inject the ACL with the grants specified in the collection of rules.
+     *
+     * @param AclAuthorization $acl
+     * @param string $grantType Either "allow" or "deny".
+     * @param array $rules
+     * @return AclAuthorization
+     */
+    private static function injectGrants(AclAuthorization $acl, $grantType, array $rules)
+    {
+        foreach ($rules as $set) {
             if (! is_array($set) || ! isset($set['resource'])) {
                 continue;
             }
 
-            // Add new resource to ACL
-            $resource = $set['resource'];
-            $acl->addResource($set['resource']);
-
-            // Deny guest specified privileges to resource
-            $privileges = isset($set['privileges']) ? $set['privileges'] : null;
-
-            // "null" privileges means no permissions were setup; nothing to do
-            if (null === $privileges) {
-                continue;
-            }
-
-            $acl->$grant('guest', $resource, $privileges);
+            self::injectGrant($acl, $grantType, $set);
         }
 
         return $acl;
+    }
+
+    /**
+     * Inject the ACL with the grant specified by a single rule set.
+     *
+     * @param AclAuthorization $acl
+     * @param string $grantType
+     * @param array $ruleSet
+     * @return void
+     */
+    private static function injectGrant(AclAuthorization $acl, $grantType, array $ruleSet)
+    {
+        // Add new resource to ACL
+        $resource = $ruleSet['resource'];
+        $acl->addResource($ruleSet['resource']);
+
+        // Deny guest specified privileges to resource
+        $privileges = isset($ruleSet['privileges']) ? $ruleSet['privileges'] : null;
+
+        // null privileges means no permissions were setup; nothing to do
+        if (null === $privileges) {
+            continue;
+        }
+
+        $acl->$grantType('guest', $resource, $privileges);
     }
 }

--- a/src/Authorization/AclAuthorizationFactory.php
+++ b/src/Authorization/AclAuthorizationFactory.php
@@ -81,7 +81,7 @@ abstract class AclAuthorizationFactory
 
         // null privileges means no permissions were setup; nothing to do
         if (null === $privileges) {
-            continue;
+            return;
         }
 
         $acl->$grantType('guest', $resource, $privileges);

--- a/src/Authorization/DefaultAuthorizationListener.php
+++ b/src/Authorization/DefaultAuthorizationListener.php
@@ -8,6 +8,7 @@ namespace ZF\MvcAuth\Authorization;
 
 use Zend\Http\Request;
 use Zend\Http\Response;
+use Zend\Mvc\Router\RouteMatch as V2RouteMatch;
 use Zend\Router\RouteMatch;
 use ZF\MvcAuth\MvcAuthEvent;
 use ZF\MvcAuth\Identity\IdentityInterface;
@@ -52,7 +53,7 @@ class DefaultAuthorizationListener
         }
 
         $routeMatch = $mvcEvent->getRouteMatch();
-        if (!$routeMatch instanceof RouteMatch) {
+        if (! ($routeMatch instanceof RouteMatch || $routeMatch instanceof V2RouteMatch)) {
             return;
         }
 

--- a/src/Authorization/DefaultResourceResolverListener.php
+++ b/src/Authorization/DefaultResourceResolverListener.php
@@ -6,7 +6,9 @@
 
 namespace ZF\MvcAuth\Authorization;
 
+use InvalidArgumentException;
 use Zend\Http\Request;
+use Zend\Mvc\Router\RouteMatch as V2RouteMatch;
 use Zend\Router\RouteMatch;
 use ZF\MvcAuth\MvcAuthEvent;
 
@@ -69,12 +71,22 @@ class DefaultResourceResolverListener
      *
      * If it cannot resolve a controller service name, boolean false is returned.
      *
-     * @param RouteMatch $routeMatch
+     * @param RouteMatch|V2RouteMatch $routeMatch
      * @param \Zend\Stdlib\RequestInterface $request
      * @return false|string
      */
-    public function buildResourceString(RouteMatch $routeMatch, $request)
+    public function buildResourceString($routeMatch, $request)
     {
+        if (! ($routeMatch instanceof RouteMatch || $routeMatch instanceof V2RouteMatch)) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expected either a %s or %s; received %s',
+                __METHOD__,
+                RouteMatch::class,
+                V2RouteMatch::class,
+                (is_object($routeMatch) ? get_class($routeMatch) : gettype($routeMatch))
+            ));
+        }
+
         // Considerations:
         // - We want the controller service name
         $controller = $routeMatch->getParam('controller', false);
@@ -107,11 +119,11 @@ class DefaultResourceResolverListener
      * as a query string parameter.
      *
      * @param string $identifierName
-     * @param RouteMatch $routeMatch
+     * @param RouteMatch|V2RouteMatch $routeMatch Validated by calling method.
      * @param \Zend\Stdlib\RequestInterface $request
      * @return false|mixed
      */
-    protected function getIdentifier($identifierName, RouteMatch $routeMatch, $request)
+    protected function getIdentifier($identifierName, $routeMatch, $request)
     {
         $id = $routeMatch->getParam($identifierName, false);
         if ($id) {

--- a/src/Factory/ApacheResolverFactory.php
+++ b/src/Factory/ApacheResolverFactory.php
@@ -1,42 +1,36 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\MvcAuth\Factory;
 
 use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
-use Zend\Authentication\Adapter\Http\ApacheResolver;
-use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 class ApacheResolverFactory implements FactoryInterface
 {
     /**
-     * Create an object
+     * Create and return an ApacheResolver instance.
      *
-     * @param  ContainerInterface $container
-     * @param  string             $requestedName
-     * @param  null|array         $options
+     * If appropriate configuration is not found, returns boolean false.
      *
-     * @return object
-     * @throws ServiceNotFoundException if unable to resolve the service.
-     * @throws ServiceNotCreatedException if an exception is raised when
-     *     creating a service.
-     * @throws ContainerException if any other error occurs
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     * @return false|ApacheResolver
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = NULL)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        if (FALSE === $container->has('config')) {
+        if (false === $container->has('config')) {
             return false;
         }
 
         $config = $container->get('config');
 
-        if (!isset($config['zf-mvc-auth']['authentication']['http']['htpasswd'])) {
+        if (! isset($config['zf-mvc-auth']['authentication']['http']['htpasswd'])) {
             return false;
         }
 
@@ -45,5 +39,16 @@ class ApacheResolverFactory implements FactoryInterface
         return new ApacheResolver($htpasswd);
     }
 
- 
+    /**
+     * Create and return an ApacheResolve instance (v2).
+     *
+     * Exists for backwards compatibility only; proxies to __invoke().
+     *
+     * @param  ServiceLocatorInterface $container
+     * @return false|ApacheResolver
+     */
+    public function createService(ServiceLocatorInterface $container)
+    {
+        return $this($container, ApacheResolver::class);
+    }
 }

--- a/src/Factory/AuthenticationHttpAdapterFactory.php
+++ b/src/Factory/AuthenticationHttpAdapterFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 namespace ZF\MvcAuth\Factory;
 
@@ -19,18 +19,17 @@ final class AuthenticationHttpAdapterFactory
     }
 
     /**
-     * Create an instance of ZF\MvcAuth\Authentication\HttpAdapter based on
-     * the configuration provided and the registered AuthenticationService.
+     * Create an instance of HttpAdapter based on the configuration provided
+     * and the registered AuthenticationService.
      *
-     * @param string                                $type The base "type" the adapter will provide
-     * @param array                                 $config
-     * @param \Interop\Container\ContainerInterface $services
-     *
-     * @return \ZF\MvcAuth\Authentication\HttpAdapter
+     * @param string $type The base "type" the adapter will provide
+     * @param array $config
+     * @param ContainerInterface $container
+     * @return HttpAdapter
      */
-    public static function factory($type, array $config, ContainerInterface $services)
+    public static function factory($type, array $config, ContainerInterface $container)
     {
-        if (! $services->has('authentication')) {
+        if (! $container->has('authentication')) {
             throw new ServiceNotCreatedException(
                 'Cannot create HTTP authentication adapter; missing AuthenticationService'
             );
@@ -43,8 +42,8 @@ final class AuthenticationHttpAdapterFactory
         }
 
         return new HttpAdapter(
-            HttpAdapterFactory::factory($config['options'], $services),
-            $services->get('authentication'),
+            HttpAdapterFactory::factory($config['options'], $container),
+            $container->get('authentication'),
             $type
         );
     }

--- a/src/Factory/AuthenticationOAuth2AdapterFactory.php
+++ b/src/Factory/AuthenticationOAuth2AdapterFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 namespace ZF\MvcAuth\Factory;
 
@@ -21,20 +21,19 @@ final class AuthenticationOAuth2AdapterFactory
     /**
      * Create and return an OAuth2Adapter instance.
      *
-     * @param string|array                          $type
-     * @param array                                 $config
-     * @param \Interop\Container\ContainerInterface $services
-     *
-     * @return \ZF\MvcAuth\Authentication\OAuth2Adapter
+     * @param string|array $type
+     * @param array $config
+     * @param ContainerInterface $services
+     * @return OAuth2Adapter
      */
-    public static function factory($type, array $config, ContainerInterface $services)
+    public static function factory($type, array $config, ContainerInterface $container)
     {
         if (! isset($config['storage']) || ! is_array($config['storage'])) {
             throw new ServiceNotCreatedException('Missing storage details for OAuth2 server');
         }
 
         return new OAuth2Adapter(
-            OAuth2ServerFactory::factory($config['storage'], $services),
+            OAuth2ServerFactory::factory($config['storage'], $container),
             $type
         );
     }

--- a/src/Factory/AuthenticationServiceFactory.php
+++ b/src/Factory/AuthenticationServiceFactory.php
@@ -1,37 +1,42 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\MvcAuth\Factory;
 
 use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
 use Zend\Authentication\AuthenticationService;
 use Zend\Authentication\Storage\NonPersistent;
-use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 class AuthenticationServiceFactory implements FactoryInterface
 {
     /**
-     * Create an object
+     * Create and return an AuthenticationService instance.
      *
-     * @param  ContainerInterface $container
-     * @param  string             $requestedName
-     * @param  null|array         $options
-     *
-     * @return object
-     * @throws ServiceNotFoundException if unable to resolve the service.
-     * @throws ServiceNotCreatedException if an exception is raised when
-     *     creating a service.
-     * @throws ContainerException if any other error occurs
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     * @return AuthenticationService
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = NULL)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         return new AuthenticationService($container->get(NonPersistent::class));
     }
 
+    /**
+     * Create and return an AuthenticationService instance (v2).
+     *
+     * Provided for backwards compatibility; proxies to __invoke().
+     *
+     * @param ServiceLocatorInterface $container
+     * @return AuthenticationService
+     */
+    public function createService(ServiceLocatorInterface $container)
+    {
+        return $this($container, AuthenticationService::class);
+    }
 }

--- a/src/Factory/DefaultAuthHttpAdapterFactory.php
+++ b/src/Factory/DefaultAuthHttpAdapterFactory.php
@@ -1,51 +1,56 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\MvcAuth\Factory;
 
 use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
 use Zend\Authentication\Adapter\Http as HttpAuth;
-use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
- * Factory for creating the DefaultAuthHttpAdapterFactory from configuration
+ * Factory for creating the DefaultAuthHttpAdapterFactory from configuration.
  */
 class DefaultAuthHttpAdapterFactory implements FactoryInterface
 {
     /**
      * Create an object
      *
-     * @param  ContainerInterface $container
-     * @param  string             $requestedName
-     * @param  null|array         $options
-     *
-     * @return object
-     * @throws ServiceNotFoundException if unable to resolve the service.
-     * @throws ServiceNotCreatedException if an exception is raised when
-     *     creating a service.
-     * @throws ContainerException if any other error occurs
+     * @param ContainerInterface $container
+     * @param string             $requestedName
+     * @param null|array         $options
+     * @return HttpAuth
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = NULL)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         // If no configuration present, nothing to create
-        if (!$container->has('config')) {
+        if (! $container->has('config')) {
             return false;
         }
 
         $config = $container->get('config');
 
         // If no HTTP adapter configuration present, nothing to create
-        if (!isset($config['zf-mvc-auth']['authentication']['http'])) {
+        if (! isset($config['zf-mvc-auth']['authentication']['http'])) {
             return false;
         }
 
         return HttpAdapterFactory::factory($config['zf-mvc-auth']['authentication']['http'], $container);
     }
 
+    /**
+     * Create and return an HTTP authentication adapter instance (v2).
+     *
+     * Provided for backwards compatibility; proxies to __invoke().
+     *
+     * @param ServiceLocatorInterface $container
+     * @return HttpAuth
+     */
+    public function createService(ServiceLocatorInterface $container)
+    {
+        return $this($container, HttpAuth::class);
+    }
 }

--- a/src/Factory/DefaultAuthenticationListenerFactory.php
+++ b/src/Factory/DefaultAuthenticationListenerFactory.php
@@ -76,7 +76,7 @@ class DefaultAuthenticationListenerFactory implements FactoryInterface
         // or no HTTP adapter configuration provided to zf-mvc-auth, we can stop early.
 
         $httpAdapter = $container->get('ZF\MvcAuth\Authentication\AuthHttpAdapter');
-        
+
         if ($httpAdapter === false) {
             return false;
         }

--- a/src/Factory/DefaultAuthorizationListenerFactory.php
+++ b/src/Factory/DefaultAuthorizationListenerFactory.php
@@ -1,48 +1,55 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\MvcAuth\Factory;
 
 use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\MvcAuth\Authorization\AuthorizationInterface;
 use ZF\MvcAuth\Authorization\DefaultAuthorizationListener;
 
 /**
- * Factory for creating the DefaultAuthorizationListener from configuration
+ * Factory for creating the DefaultAuthorizationListener from configuration.
  */
 class DefaultAuthorizationListenerFactory implements FactoryInterface
 {
     /**
-     * Create an object
+     * Create and return the default authorization listener.
      *
-     * @param  ContainerInterface $container
-     * @param  string             $requestedName
-     * @param  null|array         $options
-     *
-     * @return object
-     * @throws ServiceNotFoundException if unable to resolve the service.
-     * @throws ServiceNotCreatedException if an exception is raised when
-     *     creating a service.
-     * @throws ContainerException if any other error occurs
+     * @param ContainerInterface $container
+     * @param string             $requestedName
+     * @param null|array         $options
+     * @return DefaultAuthorizationListenerFactory
+     * @throws ServiceNotCreatedException if the AuthorizationInterface service is missing.
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = NULL)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        if (!$container->has('ZF\MvcAuth\Authorization\AuthorizationInterface')) {
-            throw new ServiceNotCreatedException(
-                'Cannot create DefaultAuthorizationListener service; '
-                . 'no ZF\MvcAuth\Authorization\AuthorizationInterface service available!'
-            );
+        if (! $container->has(AuthorizationInterface::class)) {
+            throw new ServiceNotCreatedException(sprintf(
+                'Cannot create %s service; no %s service available!',
+                DefaultAuthorizationListener::class,
+                AuthorizationInterface::class
+            ));
         }
 
-        return new DefaultAuthorizationListener(
-            $container->get('ZF\MvcAuth\Authorization\AuthorizationInterface')
-        );
+        return new DefaultAuthorizationListener($container->get(AuthorizationInterface::class));
     }
 
+    /**
+     * Create and return the default authorization listener (v2).
+     *
+     * Provided for backwards compatibility; proxies to __invoke().
+     *
+     * @param ServiceLocatorInterface $container
+     * @return DefaultAuthorizationListenerFactory
+     */
+    public function createService(ServiceLocatorInterface $container)
+    {
+        return $this($container, DefaultAuthorizationListener::class);
+    }
 }

--- a/src/Factory/DefaultResourceResolverListenerFactory.php
+++ b/src/Factory/DefaultResourceResolverListenerFactory.php
@@ -1,21 +1,19 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\MvcAuth\Factory;
 
 use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
 use Zend\Http\Request;
-use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\MvcAuth\Authorization\DefaultResourceResolverListener;
 
 /**
- * Factory for creating the DefaultResourceResolverListener from configuration
+ * Factory for creating the DefaultResourceResolverListener from configuration.
  */
 class DefaultResourceResolverListenerFactory implements FactoryInterface
 {
@@ -28,30 +26,34 @@ class DefaultResourceResolverListenerFactory implements FactoryInterface
     ];
 
     /**
-     * Create an object
+     * Create and return a DefaultResourceResolverListener instance.
      *
-     * @param  ContainerInterface $container
-     * @param  string             $requestedName
-     * @param  null|array         $options
-     *
-     * @return object
-     * @throws ServiceNotFoundException if unable to resolve the service.
-     * @throws ServiceNotCreatedException if an exception is raised when
-     *     creating a service.
-     * @throws ContainerException if any other error occurs
+     * @param ContainerInterface $container
+     * @param string             $requestedName
+     * @param null|array         $options
+     * @return DefaultResourceResolverListener
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = NULL)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $config = [];
-        if ($container->has('config')) {
-            $config = $container->get('config');
-        }
+        $config = $container->has('config') ?  $container->get('config') : [];
 
         return new DefaultResourceResolverListener(
             $this->getRestServicesFromConfig($config)
         );
     }
 
+    /**
+     * Create and return a DefaultResourceResolverListener instance (v2).
+     *
+     * Provided for backwards compatibility; proxies to __invoke().
+     *
+     * @param ServiceLocatorInterface $container
+     * @return DefaultResourceResolverListener
+     */
+    public function createService(ServiceLocatorInterface $container)
+    {
+        return $this($container, DefaultResourceResolverListener::class);
+    }
 
     /**
      * Generate the list of REST services for the listener
@@ -65,12 +67,12 @@ class DefaultResourceResolverListenerFactory implements FactoryInterface
     protected function getRestServicesFromConfig(array $config)
     {
         $restServices = [];
-        if (!isset($config['zf-rest'])) {
+        if (! isset($config['zf-rest'])) {
             return $restServices;
         }
 
         foreach ($config['zf-rest'] as $controllerService => $restConfig) {
-            if (!isset($restConfig['route_identifier_name'])) {
+            if (! isset($restConfig['route_identifier_name'])) {
                 continue;
             }
             $restServices[$controllerService] = $restConfig['route_identifier_name'];

--- a/src/Factory/FileResolverFactory.php
+++ b/src/Factory/FileResolverFactory.php
@@ -1,42 +1,35 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\MvcAuth\Factory;
 
 use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
 use Zend\Authentication\Adapter\Http\FileResolver;
-use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 class FileResolverFactory implements FactoryInterface
 {
     /**
-     * Create an object
+     * Create and return a FileResolver instance, if configured.
      *
-     * @param  ContainerInterface $container
-     * @param  string             $requestedName
-     * @param  null|array         $options
-     *
-     * @return object
-     * @throws ServiceNotFoundException if unable to resolve the service.
-     * @throws ServiceNotCreatedException if an exception is raised when
-     *     creating a service.
-     * @throws ContainerException if any other error occurs
+     * @param ContainerInterface $container
+     * @param string             $requestedName
+     * @param null|array         $options
+     * @return false|FileResolver
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = NULL)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        if (!$container->has('config')) {
+        if (! $container->has('config')) {
             return false;
         }
 
         $config = $container->get('config');
 
-        if (!isset($config['zf-mvc-auth']['authentication']['http']['htdigest'])) {
+        if (! isset($config['zf-mvc-auth']['authentication']['http']['htdigest'])) {
             return false;
         }
 
@@ -45,4 +38,16 @@ class FileResolverFactory implements FactoryInterface
         return new FileResolver($htdigest);
     }
 
+    /**
+     * Create and return a FileResolver instance, if configured (v2).
+     *
+     * Provided for backwards compatibility; proxies to __invoke().
+     *
+     * @param ServiceLocatorInterface $container
+     * @return false|FileResolver
+     */
+    public function createService(ServiceLocatorInterface $container)
+    {
+        return $this($container, FileResolver::class);
+    }
 }

--- a/src/Factory/HttpAdapterFactory.php
+++ b/src/Factory/HttpAdapterFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 namespace ZF\MvcAuth\Factory;
 
@@ -10,7 +10,6 @@ use Zend\Authentication\Adapter\Http as HttpAuth;
 use Zend\Authentication\Adapter\Http\ApacheResolver;
 use Zend\Authentication\Adapter\Http\FileResolver;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Create and return a Zend\Authentication\Adapter\Http instance based on the
@@ -28,12 +27,11 @@ final class HttpAdapterFactory
     /**
      * Create an HttpAuth instance based on the configuration passed.
      *
-     * @param array                                 $config
-     * @param \Interop\Container\ContainerInterface $serviceLocator
-     *
-     * @return \Zend\Authentication\Adapter\Http
+     * @param array $config
+     * @param null|ContainerInterface $container
+     * @return HttpAuth
      */
-    public static function factory(array $config, ContainerInterface $serviceLocator = null)
+    public static function factory(array $config, ContainerInterface $container = null)
     {
         if (! isset($config['accept_schemes']) || ! is_array($config['accept_schemes'])) {
             throw new ServiceNotCreatedException(
@@ -67,9 +65,9 @@ final class HttpAdapterFactory
 
         if (in_array('basic', $config['accept_schemes'])) {
             if (isset($config['basic_resolver_factory'])
-                && self::serviceLocatorHasKey($serviceLocator, $config['basic_resolver_factory'])
+                && self::containerHasKey($container, $config['basic_resolver_factory'])
             ) {
-                $httpAdapter->setBasicResolver($serviceLocator->get($config['basic_resolver_factory']));
+                $httpAdapter->setBasicResolver($container->get($config['basic_resolver_factory']));
             } elseif (isset($config['htpasswd'])) {
                 $httpAdapter->setBasicResolver(new ApacheResolver($config['htpasswd']));
             }
@@ -77,9 +75,9 @@ final class HttpAdapterFactory
 
         if (in_array('digest', $config['accept_schemes'])) {
             if (isset($config['digest_resolver_factory'])
-                && self::serviceLocatorHasKey($serviceLocator, $config['digest_resolver_factory'])
+                && self::containerHasKey($container, $config['digest_resolver_factory'])
             ) {
-                $httpAdapter->setDigestResolver($serviceLocator->get($config['digest_resolver_factory']));
+                $httpAdapter->setDigestResolver($container->get($config['digest_resolver_factory']));
             } elseif (isset($config['htdigest'])) {
                 $httpAdapter->setDigestResolver(new FileResolver($config['htdigest']));
             }
@@ -89,19 +87,18 @@ final class HttpAdapterFactory
     }
 
     /**
-     * @param \Interop\Container\ContainerInterface $serviceLocator
-     * @param null                                  $key
-     *
+     * @param ContainerInterface $container
+     * @param null $key
      * @return bool
      */
-    private static function serviceLocatorHasKey(ContainerInterface $serviceLocator = null, $key = null)
+    private static function containerHasKey(ContainerInterface $container = null, $key = null)
     {
-        if (!$serviceLocator instanceof ContainerInterface) {
+        if (! $container instanceof ContainerInterface) {
             return false;
         }
-        if (!is_string($key)) {
+        if (! is_string($key)) {
             return false;
         }
-        return $serviceLocator->has($key);
+        return $container->has($key);
     }
 }

--- a/src/Factory/NamedOAuth2ServerFactory.php
+++ b/src/Factory/NamedOAuth2ServerFactory.php
@@ -1,16 +1,12 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 namespace ZF\MvcAuth\Factory;
 
 use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
 use RuntimeException;
-use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\Factory\FactoryInterface;
 use ZF\OAuth2\Factory\OAuth2ServerInstanceFactory;
 
 /**
@@ -21,24 +17,15 @@ use ZF\OAuth2\Factory\OAuth2ServerInstanceFactory;
  * ZF\OAuth2\Factory\OAuth2ServerInstanceFactory after first marshaling the
  * correct configuration from zf-mvc-auth.authentication.adapters.
  */
-class NamedOAuth2ServerFactory implements FactoryInterface
+class NamedOAuth2ServerFactory
 {
     /**
-     * Create an object
-     *
-     * @param  ContainerInterface $container
-     * @param  string             $requestedName
-     * @param  null|array         $options
-     *
-     * @return object
-     * @throws ServiceNotFoundException if unable to resolve the service.
-     * @throws ServiceNotCreatedException if an exception is raised when
-     *     creating a service.
-     * @throws ContainerException if any other error occurs
+     * @param ContainerInterface $container
+     * @return callable
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = NULL)
+    public function __invoke(ContainerInterface $container)
     {
-        $config = $container->get('Config');
+        $config = $container->get('config');
 
         $oauth2Config  = isset($config['zf-oauth2']) ? $config['zf-oauth2'] : [];
         $mvcAuthConfig = isset($config['zf-mvc-auth']['authentication']['adapters'])
@@ -87,6 +74,4 @@ class NamedOAuth2ServerFactory implements FactoryInterface
             return $servers->application = $factory();
         };
     }
-
-
 }

--- a/src/Factory/OAuth2ServerFactory.php
+++ b/src/Factory/OAuth2ServerFactory.php
@@ -29,19 +29,18 @@ final class OAuth2ServerFactory
     /**
      * Create and return a fully configured OAuth2 server instance.
      *
-     * @param array                                 $config
-     * @param \Interop\Container\ContainerInterface $services
-     *
+     * @param array $config
+     * @param ContainerInterface $container
      * @return \OAuth2\Server
      */
-    public static function factory(array $config, ContainerInterface $services)
+    public static function factory(array $config, ContainerInterface $container)
     {
-        $allConfig    = $services->get('Config');
+        $allConfig    = $container->get('Config');
         $oauth2Config = isset($allConfig['zf-oauth2']) ? $allConfig['zf-oauth2'] : [];
         $options      = self::marshalOptions($oauth2Config);
 
         $oauth2Server = new OAuth2Server(
-            self::createStorage(array_merge($oauth2Config, $config), $services),
+            self::createStorage(array_merge($oauth2Config, $config), $container),
             $options
         );
 
@@ -51,21 +50,20 @@ final class OAuth2ServerFactory
     /**
      * Create and return an OAuth2 storage adapter instance.
      *
-     * @param array                                 $config
-     * @param \Interop\Container\ContainerInterface $services
-     *
-     * @return array|\ZF\OAuth2\Adapter\MongoAdapter|\ZF\OAuth2\Adapter\PdoAdapter A PdoAdapter, MongoAdapter, or array of storage instances.
+     * @param array $config
+     * @param ContainerInterface $container
+     * @return array|MongoAdapter|PdoAdapter A PdoAdapter, MongoAdapter, or array of storage instances.
      */
-    private static function createStorage(array $config, ContainerInterface $services)
+    private static function createStorage(array $config, ContainerInterface $container)
     {
         if (isset($config['adapter']) && is_string($config['adapter'])) {
-            return self::createStorageFromAdapter($config['adapter'], $config, $services);
+            return self::createStorageFromAdapter($config['adapter'], $config, $container);
         }
 
         if (isset($config['storage'])
             && (is_string($config['storage']) || is_array($config['storage']))
         ) {
-            return self::createStorageFromServices($config['storage'], $services);
+            return self::createStorageFromServices($config['storage'], $container);
         }
 
         throw new ServiceNotCreatedException('Missing or invalid storage adapter information for OAuth2');
@@ -74,19 +72,18 @@ final class OAuth2ServerFactory
     /**
      * Create an OAuth2 storage instance based on the adapter specified.
      *
-     * @param string                                $adapter One of "pdo" or "mongo".
-     * @param array                                 $config
-     * @param \Interop\Container\ContainerInterface $services
-     *
-     * @return \ZF\OAuth2\Adapter\MongoAdapter|\ZF\OAuth2\Adapter\PdoAdapter
+     * @param string $adapter One of "pdo" or "mongo".
+     * @param array $config
+     * @param ContainerInterface $container
+     * @return MongoAdapter|PdoAdapter
      */
-    private static function createStorageFromAdapter($adapter, array $config, ContainerInterface $services)
+    private static function createStorageFromAdapter($adapter, array $config, ContainerInterface $container)
     {
         switch (strtolower($adapter)) {
             case 'pdo':
                 return self::createPdoAdapter($config);
             case 'mongo':
-                return self::createMongoAdapter($config, $services);
+                return self::createMongoAdapter($config, $container);
             default:
                 throw new ServiceNotCreatedException('Invalid storage adapter type for OAuth2');
         }
@@ -95,24 +92,25 @@ final class OAuth2ServerFactory
     /**
      * Creates the OAuth2 storage from services.
      *
-     * @param string|string[]                       $storage A string or an array of strings; each MUST be a valid service.
-     * @param \Interop\Container\ContainerInterface $services
-     *
+     * @param string|string[] $storage A string or an array of strings; each MUST be a valid service.
+     * @param ContainerInterface $container
      * @return array
      */
-    private static function createStorageFromServices($storage, ContainerInterface $services)
+    private static function createStorageFromServices($storage, ContainerInterface $container)
     {
         $storageServices = [];
+
         if (is_string($storage)) {
             $storageServices[] = $storage;
         }
+
         if (is_array($storage)) {
             $storageServices = $storage;
         }
 
         $storage = [];
         foreach ($storageServices as $key => $service) {
-            $storage[$key] = $services->get($service);
+            $storage[$key] = $container->get($service);
         }
         return $storage;
     }
@@ -134,15 +132,14 @@ final class OAuth2ServerFactory
     /**
      * Create and return an OAuth2 Mongo adapter.
      *
-     * @param array                                 $config
-     * @param \Interop\Container\ContainerInterface $services
-     *
-     * @return \ZF\OAuth2\Adapter\MongoAdapter
+     * @param array $config
+     * @param ContainerInterface $container
+     * @return MongoAdapter
      */
-    private static function createMongoAdapter(array $config, ContainerInterface $services)
+    private static function createMongoAdapter(array $config, ContainerInterface $container)
     {
         return new MongoAdapter(
-            self::createMongoDatabase($config, $services),
+            self::createMongoDatabase($config, $container),
             self::getOAuth2ServerConfig($config)
         );
     }
@@ -176,19 +173,18 @@ final class OAuth2ServerFactory
     /**
      * Create and return a Mongo database instance.
      *
-     * @param array                                 $config
-     * @param \Interop\Container\ContainerInterface $services
-     *
+     * @param array $config
+     * @param ContainerInterface $container
      * @return \MongoDB
      */
-    private static function createMongoDatabase(array $config, ContainerInterface $services)
+    private static function createMongoDatabase(array $config, ContainerInterface $container)
     {
         $dbLocatorName = isset($config['locator_name'])
             ? $config['locator_name']
             : 'MongoDB';
 
-        if ($services->has($dbLocatorName)) {
-            return $services->get($dbLocatorName);
+        if ($container->has($dbLocatorName)) {
+            return $container->get($dbLocatorName);
         }
 
         if (! isset($config['database'])) {
@@ -241,7 +237,7 @@ final class OAuth2ServerFactory
         $audience = isset($config['audience'])
             ? $config['audience']
             : '';
-        $options        = isset($config['options'])
+        $options = isset($config['options'])
             ? $config['options']
             : [];
 

--- a/src/Factory/OAuth2ServerFactory.php
+++ b/src/Factory/OAuth2ServerFactory.php
@@ -35,7 +35,7 @@ final class OAuth2ServerFactory
      */
     public static function factory(array $config, ContainerInterface $container)
     {
-        $allConfig    = $container->get('Config');
+        $allConfig    = $container->get('config');
         $oauth2Config = isset($allConfig['zf-oauth2']) ? $allConfig['zf-oauth2'] : [];
         $options      = self::marshalOptions($oauth2Config);
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -13,7 +13,7 @@ use Zend\Mvc\MvcEvent;
 
 class Module
 {
-    protected $services;
+    protected $container;
 
     /**
      * Retrieve module configuration
@@ -22,7 +22,7 @@ class Module
      */
     public function getConfig()
     {
-        return include __DIR__ . '/config/module.config.php';
+        return include __DIR__ . '/../config/module.config.php';
     }
 
     /**
@@ -69,28 +69,28 @@ class Module
 
         $app      = $mvcEvent->getApplication();
         $events   = $app->getEventManager();
-        $this->services = $app->getServiceManager();
+        $this->container = $app->getServiceManager();
 
         $events->attach(
             MvcAuthEvent::EVENT_AUTHENTICATION,
-            $this->services->get('ZF\MvcAuth\Authentication\DefaultAuthenticationListener')
+            $this->container->get('ZF\MvcAuth\Authentication\DefaultAuthenticationListener')
         );
         $events->attach(
             MvcAuthEvent::EVENT_AUTHENTICATION_POST,
-            $this->services->get('ZF\MvcAuth\Authentication\DefaultAuthenticationPostListener')
+            $this->container->get('ZF\MvcAuth\Authentication\DefaultAuthenticationPostListener')
         );
         $events->attach(
             MvcAuthEvent::EVENT_AUTHORIZATION,
-            $this->services->get('ZF\MvcAuth\Authorization\DefaultResourceResolverListener'),
+            $this->container->get('ZF\MvcAuth\Authorization\DefaultResourceResolverListener'),
             1000
         );
         $events->attach(
             MvcAuthEvent::EVENT_AUTHORIZATION,
-            $this->services->get('ZF\MvcAuth\Authorization\DefaultAuthorizationListener')
+            $this->container->get('ZF\MvcAuth\Authorization\DefaultAuthorizationListener')
         );
         $events->attach(
             MvcAuthEvent::EVENT_AUTHORIZATION_POST,
-            $this->services->get('ZF\MvcAuth\Authorization\DefaultAuthorizationPostListener')
+            $this->container->get('ZF\MvcAuth\Authorization\DefaultAuthorizationPostListener')
         );
 
         $events->attach(
@@ -102,10 +102,10 @@ class Module
 
     public function onAuthenticationPost(MvcAuthEvent $e)
     {
-        if ($this->services->has('api-identity')) {
+        if ($this->container->has('api-identity')) {
             return;
         }
 
-        $this->services->setService('api-identity', $e->getIdentity());
+        $this->container->setService('api-identity', $e->getIdentity());
     }
 }

--- a/src/Module.php
+++ b/src/Module.php
@@ -33,7 +33,7 @@ class Module
     public function init(ModuleManager $moduleManager)
     {
         $events = $moduleManager->getEventManager();
-        $events->attach(ModuleEvent::EVENT_MERGE_CONFIG, array($this, 'onMergeConfig'));
+        $events->attach(ModuleEvent::EVENT_MERGE_CONFIG, [$this, 'onMergeConfig']);
     }
 
     /**
@@ -95,7 +95,7 @@ class Module
 
         $events->attach(
             MvcAuthEvent::EVENT_AUTHENTICATION_POST,
-            array($this, 'onAuthenticationPost'),
+            [$this, 'onAuthenticationPost'],
             -1
         );
     }

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\MvcAuth;
@@ -14,18 +14,6 @@ use Zend\Mvc\MvcEvent;
 class Module
 {
     protected $services;
-
-    /**
-     * Retrieve autoloader configuration
-     *
-     * @return array
-     */
-    public function getAutoloaderConfig()
-    {
-        return array('Zend\Loader\StandardAutoloader' => array('namespaces' => array(
-            __NAMESPACE__ => __DIR__ . '/src/',
-        )));
-    }
 
     /**
      * Retrieve module configuration

--- a/test/Authentication/DefaultAuthenticationListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationListenerTest.php
@@ -15,15 +15,17 @@ use Zend\Authentication\Storage\NonPersistent;
 use Zend\Http\Request as HttpRequest;
 use Zend\Http\Response as HttpResponse;
 use Zend\Mvc\MvcEvent;
-use Zend\Router\RouteMatch;
 use Zend\Stdlib\Request;
 use ZF\MvcAuth\Authentication\DefaultAuthenticationListener;
 use ZF\MvcAuth\Authentication\HttpAdapter;
 use ZF\MvcAuth\Authentication\OAuth2Adapter;
 use ZF\MvcAuth\MvcAuthEvent;
+use ZFTest\MvcAuth\RouteMatchFactoryTrait;
 
 class DefaultAuthenticationListenerTest extends TestCase
 {
+    use RouteMatchFactoryTrait;
+
     /**
      * @var HttpRequest
      */
@@ -425,7 +427,7 @@ class DefaultAuthenticationListenerTest extends TestCase
             'Baz\V3' => 'digest',
         ];
         $this->listener->setAuthMap($map);
-        $routeMatch = new RouteMatch(['controller' => $controller]);
+        $routeMatch = $this->createRouteMatch(['controller' => $controller]);
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $mvcEvent
             ->setRequest($request)
@@ -461,7 +463,7 @@ class DefaultAuthenticationListenerTest extends TestCase
             'Baz\V3' => 'digest',
         ];
         $this->listener->setAuthMap($map);
-        $routeMatch = new RouteMatch(['controller' => $controller]);
+        $routeMatch = $this->createRouteMatch(['controller' => $controller]);
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $mvcEvent
             ->setRequest($requestProvider())
@@ -493,7 +495,7 @@ class DefaultAuthenticationListenerTest extends TestCase
                 break;
         }
 
-        $routeMatch = new RouteMatch(['controller' => $controller]);
+        $routeMatch = $this->createRouteMatch(['controller' => $controller]);
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $mvcEvent
             ->setRequest($requestProvider())
@@ -518,7 +520,7 @@ class DefaultAuthenticationListenerTest extends TestCase
             ->getMock();
         $this->listener->setOauth2Server($server);
 
-        $routeMatch = new RouteMatch(['controller' => $controller]);
+        $routeMatch = $this->createRouteMatch(['controller' => $controller]);
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $mvcEvent
             ->setRequest($requestProvider())
@@ -555,7 +557,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $request = new HttpRequest();
         $request->getHeaders()->addHeaderLine('Authorization: Bearer TOKEN');
 
-        $routeMatch = new RouteMatch(['controller' => 'FooBarBaz\V4\Rest\Test\TestController']);
+        $routeMatch = $this->createRouteMatch(['controller' => 'FooBarBaz\V4\Rest\Test\TestController']);
 
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $mvcEvent
@@ -589,7 +591,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $request = new HttpRequest();
         $request->getHeaders()->addHeaderLine('Authorization: Bearer TOKEN');
 
-        $routeMatch = new RouteMatch(['controller' => 'Foo\V2\Rest\Test\TestController']);
+        $routeMatch = $this->createRouteMatch(['controller' => 'Foo\V2\Rest\Test\TestController']);
 
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $mvcEvent
@@ -634,7 +636,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         ];
         $this->listener->setAuthMap($map);
         $request    = new HttpRequest();
-        $routeMatch = new RouteMatch(['controller' => 'Foo\V1\Rest\Test\TestController']);
+        $routeMatch = $this->createRouteMatch(['controller' => 'Foo\V1\Rest\Test\TestController']);
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $mvcEvent
             ->setRequest($request)
@@ -671,7 +673,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         ];
         $this->listener->setAuthMap($map);
         $request    = new HttpRequest();
-        $routeMatch = new RouteMatch(['controller' => 'Foo\V2\Rest\Test\TestController']);
+        $routeMatch = $this->createRouteMatch(['controller' => 'Foo\V2\Rest\Test\TestController']);
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $mvcEvent
             ->setRequest($request)
@@ -714,7 +716,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         ];
         $this->listener->setAuthMap($map);
         $request    = new HttpRequest();
-        $routeMatch = new RouteMatch(['controller' => 'Foo\V2\Rest\Test\TestController']);
+        $routeMatch = $this->createRouteMatch(['controller' => 'Foo\V2\Rest\Test\TestController']);
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $mvcEvent
             ->setRequest($request)
@@ -820,7 +822,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         ];
         $this->listener->setAuthMap($map);
         $request    = new HttpRequest();
-        $routeMatch = new RouteMatch(['controller' => 'Foo\V2\Rest\Test\TestController']);
+        $routeMatch = $this->createRouteMatch(['controller' => 'Foo\V2\Rest\Test\TestController']);
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $mvcEvent
             ->setRequest($request)

--- a/test/Authentication/DefaultAuthenticationListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationListenerTest.php
@@ -69,7 +69,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->authentication = new AuthenticationService(new NonPersistent());
 
         // authorization service
-        $this->authorization = $this->getMock('ZF\MvcAuth\Authorization\AuthorizationInterface');
+        $this->authorization = $this->getMockBuilder('ZF\MvcAuth\Authorization\AuthorizationInterface')->getMock();
 
         // event for mvc and mvc-auth
         $this->request    = new HttpRequest();

--- a/test/Authentication/HttpAdapterTest.php
+++ b/test/Authentication/HttpAdapterTest.php
@@ -33,7 +33,7 @@ class HttpAdapterTest extends TestCase
         $this->event = new MvcAuthEvent(
             $mvcEvent,
             $this->authentication,
-            $this->getMock('ZF\MvcAuth\Authorization\AuthorizationInterface')
+            $this->getMockBuilder('ZF\MvcAuth\Authorization\AuthorizationInterface')->getMock()
         );
     }
 

--- a/test/Authentication/OAuth2AdapterTest.php
+++ b/test/Authentication/OAuth2AdapterTest.php
@@ -17,7 +17,7 @@ class OAuth2AdapterTest extends TestCase
 {
     public function setUp()
     {
-        $this->oauthServer = $this->getMock('OAuth2\Server');
+        $this->oauthServer = $this->getMockBuilder('OAuth2\Server')->getMock();
         $this->adapter = new OAuth2Adapter($this->oauthServer);
     }
 

--- a/test/Authentication/UnauthenticatedListenerTest.php
+++ b/test/Authentication/UnauthenticatedListenerTest.php
@@ -30,7 +30,7 @@ class DefaultAuthenticationPostListenerTest extends TestCase
     public function createMvcAuthEvent(MvcEvent $mvcEvent)
     {
         $this->authentication = new TestAsset\AuthenticationService();
-        $this->authorization  = $this->getMock('ZF\MvcAuth\Authorization\AuthorizationInterface');
+        $this->authorization  = $this->getMockBuilder('ZF\MvcAuth\Authorization\AuthorizationInterface')->getMock();
         return new MvcAuthEvent($mvcEvent, $this->authentication, $this->authorization);
     }
 

--- a/test/Authorization/DefaultAuthorizationPostListenerTest.php
+++ b/test/Authorization/DefaultAuthorizationPostListenerTest.php
@@ -29,7 +29,7 @@ class DefaultAuthorizationPostListenerTest extends TestCase
     public function createMvcAuthEvent(MvcEvent $mvcEvent)
     {
         $this->authentication = new TestAsset\AuthenticationService();
-        $this->authorization  = $this->getMock('ZF\MvcAuth\Authorization\AuthorizationInterface');
+        $this->authorization  = $this->getMockBuilder('ZF\MvcAuth\Authorization\AuthorizationInterface')->getMock();
         return new MvcAuthEvent($mvcEvent, $this->authentication, $this->authorization);
     }
 

--- a/test/Authorization/DefaultResourceResolverListenerTest.php
+++ b/test/Authorization/DefaultResourceResolverListenerTest.php
@@ -41,7 +41,7 @@ class DefaultResourceResolverListenerTest extends TestCase
     public function createMvcAuthEvent(MvcEvent $mvcEvent)
     {
         $this->authentication = new TestAsset\AuthenticationService();
-        $this->authorization  = $this->getMock('ZF\MvcAuth\Authorization\AuthorizationInterface');
+        $this->authorization  = $this->getMockBuilder('ZF\MvcAuth\Authorization\AuthorizationInterface')->getMock();
         return new MvcAuthEvent($mvcEvent, $this->authentication, $this->authorization);
     }
 

--- a/test/Authorization/DefaultResourceResolverListenerTest.php
+++ b/test/Authorization/DefaultResourceResolverListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZFTest\MvcAuth\Authorization;
@@ -10,18 +10,20 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Http\Request as HttpRequest;
 use Zend\Http\Response as HttpResponse;
 use Zend\Mvc\MvcEvent;
-use Zend\Router\RouteMatch;
 use Zend\Stdlib\Request;
 use Zend\Stdlib\Response;
 use ZF\MvcAuth\Authorization\DefaultResourceResolverListener;
 use ZF\MvcAuth\MvcAuthEvent;
+use ZFTest\MvcAuth\RouteMatchFactoryTrait;
 use ZFTest\MvcAuth\TestAsset;
 
 class DefaultResourceResolverListenerTest extends TestCase
 {
+    use RouteMatchFactoryTrait;
+
     public function setUp()
     {
-        $routeMatch = new RouteMatch([]);
+        $routeMatch = $this->createRouteMatch([]);
         $request    = new HttpRequest();
         $response   = new HttpResponse();
         $mvcEvent   = new MvcEvent();

--- a/test/Factory/AclAuthorizationFactoryTest.php
+++ b/test/Factory/AclAuthorizationFactoryTest.php
@@ -125,7 +125,7 @@ class AclAuthorizationFactoryTest extends TestCase
         $factory = $this->factory;
 
         $acl = $factory($this->services, 'AclAuthorization');
-        
+
         $this->assertInstanceOf('ZF\MvcAuth\Authorization\AclAuthorization', $acl);
 
         $authorizations = $config['zf-mvc-auth']['authorization'];

--- a/test/Factory/AuthenticationAdapterDelegatorFactoryTest.php
+++ b/test/Factory/AuthenticationAdapterDelegatorFactoryTest.php
@@ -37,7 +37,7 @@ class AuthenticationAdapterDelegatorFactoryTest extends TestCase
     public function testReturnsListenerWithNoAdaptersWhenNoAdaptersAreInConfiguration()
     {
         $config = [];
-        $this->services->setService('Config', $config);
+        $this->services->setService('config', $config);
 
         $factory = $this->factory;
 
@@ -93,8 +93,11 @@ class AuthenticationAdapterDelegatorFactoryTest extends TestCase
                 ],
             ],
         ];
-        $this->services->setService('Config', $config);
-        $this->services->setService('authentication', $this->getMock('Zend\Authentication\AuthenticationService'));
+        $this->services->setService('config', $config);
+        $this->services->setService(
+            'authentication',
+            $this->getMockBuilder('Zend\Authentication\AuthenticationService')->getMock()
+        );
 
         $factory = $this->factory;
 

--- a/test/Factory/AuthenticationHttpAdapterFactoryTest.php
+++ b/test/Factory/AuthenticationHttpAdapterFactoryTest.php
@@ -13,7 +13,7 @@ class AuthenticationHttpAdapterFactoryTest extends TestCase
 {
     public function setUp()
     {
-        $this->services = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $this->services = $this->getMockBuilder('Zend\ServiceManager\ServiceLocatorInterface')->getMock();
     }
 
     public function testRaisesExceptionIfNoAuthenticationServicePresent()
@@ -91,7 +91,7 @@ class AuthenticationHttpAdapterFactoryTest extends TestCase
      */
     public function testCreatesHttpAdapterWhenConfigurationIsValid(array $options, array $provides)
     {
-        $authService = $this->getMock('Zend\Authentication\AuthenticationService');
+        $authService = $this->getMockBuilder('Zend\Authentication\AuthenticationService')->getMock();
         $this->services->expects($this->atLeastOnce())
             ->method('has')
             ->with($this->equalTo('authentication'))

--- a/test/Factory/AuthenticationOAuth2AdapterFactoryTest.php
+++ b/test/Factory/AuthenticationOAuth2AdapterFactoryTest.php
@@ -13,7 +13,7 @@ class AuthenticationOAuth2AdapterFactoryTest extends TestCase
 {
     public function setUp()
     {
-        $this->services = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $this->services = $this->getMockBuilder('Zend\ServiceManager\ServiceLocatorInterface')->getMock();
     }
 
 

--- a/test/Factory/DefaultAuthenticationListenerFactoryTest.php
+++ b/test/Factory/DefaultAuthenticationListenerFactoryTest.php
@@ -8,6 +8,7 @@ namespace ZFTest\MvcAuth\Factory;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionProperty;
+use Zend\Authentication\AuthenticationServiceInterface;
 use Zend\ServiceManager\ServiceManager;
 use ZF\MvcAuth\Authentication\DefaultAuthenticationListener;
 use ZF\MvcAuth\Factory\DefaultAuthenticationListenerFactory;
@@ -161,7 +162,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
 
     public function testCallingFactoryWithBasicSchemeAndHtpasswdValueReturnsListenerWithHttpAdapter()
     {
-        $authenticationService = $this->getMock('Zend\Authentication\AuthenticationServiceInterface');
+        $authenticationService = $this->getMockBuilder(AuthenticationServiceInterface::class)->getMock();
         $this->services->setService('authentication', $authenticationService);
         $this->services->setService('config', [
             'zf-mvc-auth' => [
@@ -185,7 +186,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
 
     public function testCallingFactoryWithDigestSchemeAndHtdigestValueReturnsListenerWithHttpAdapter()
     {
-        $authenticationService = $this->getMock('Zend\Authentication\AuthenticationServiceInterface');
+        $authenticationService = $this->getMockBuilder(AuthenticationServiceInterface::class)->getMock();
         $this->services->setService('authentication', $authenticationService);
         $this->services->setService('config', [
             'zf-mvc-auth' => [
@@ -209,7 +210,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
 
     public function testCallingFactoryWithCustomAuthenticationTypesReturnsListenerComposingThem()
     {
-        $authenticationService = $this->getMock('Zend\Authentication\AuthenticationServiceInterface');
+        $authenticationService = $this->getMockBuilder(AuthenticationServiceInterface::class)->getMock();
         $this->services->setService('authentication', $authenticationService);
         $this->services->setService('config', [
             'zf-mvc-auth' => [
@@ -268,7 +269,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
 
     public function testCallingFactoryWithAuthenticationMapReturnsListenerComposingMap()
     {
-        $authenticationService = $this->getMock('Zend\Authentication\AuthenticationServiceInterface');
+        $authenticationService = $this->getMockBuilder(AuthenticationServiceInterface::class)->getMock();
         $this->services->setService('authentication', $authenticationService);
         $this->services->setService('config', [
             'zf-mvc-auth' => [

--- a/test/Factory/HttpAdapterFactoryTest.php
+++ b/test/Factory/HttpAdapterFactoryTest.php
@@ -174,14 +174,14 @@ class HttpAdapterFactoryTest extends TestCase
     {
         $keyForServiceManager = 'keyForServiceManager';
 
-        $serviceManager = $this->getMock('\Zend\ServiceManager\ServiceLocatorInterface');
+        $serviceManager = $this->getMockBuilder('\Zend\ServiceManager\ServiceLocatorInterface')->getMock();
         $serviceManager
             ->expects($this->once())
             ->method('has')
             ->with($keyForServiceManager)
             ->will($this->returnValue(true));
 
-        $resolver = $this->getMock('\Zend\Authentication\Adapter\Http\ResolverInterface');
+        $resolver = $this->getMockBuilder('\Zend\Authentication\Adapter\Http\ResolverInterface')->getMock();
         $serviceManager
             ->expects($this->once())
             ->method('get')
@@ -206,14 +206,14 @@ class HttpAdapterFactoryTest extends TestCase
     {
         $keyForServiceManager = 'keyForServiceManager';
 
-        $serviceManager = $this->getMock('\Zend\ServiceManager\ServiceLocatorInterface');
+        $serviceManager = $this->getMockBuilder('\Zend\ServiceManager\ServiceLocatorInterface')->getMock();
         $serviceManager
             ->expects($this->once())
             ->method('has')
             ->with($keyForServiceManager)
             ->will($this->returnValue(true));
 
-        $resolver = $this->getMock('\Zend\Authentication\Adapter\Http\ResolverInterface');
+        $resolver = $this->getMockBuilder('\Zend\Authentication\Adapter\Http\ResolverInterface')->getMock();
         $serviceManager
             ->expects($this->once())
             ->method('get')
@@ -252,7 +252,7 @@ class HttpAdapterFactoryTest extends TestCase
 
     public function testCanReturnAdapterWithNoResolversAndInvalidResolverKeys()
     {
-        $serviceManager = $this->getMock('\Zend\ServiceManager\ServiceLocatorInterface');
+        $serviceManager = $this->getMockBuilder('\Zend\ServiceManager\ServiceLocatorInterface')->getMock();
         $serviceManager->expects($this->never())->method('has');
 
         $adapter = HttpAdapterFactory::factory([
@@ -273,7 +273,7 @@ class HttpAdapterFactoryTest extends TestCase
     {
         $missingKeyForServiceManager = 'missingKeyForServiceManager';
 
-        $serviceManager = $this->getMock('\Zend\ServiceManager\ServiceLocatorInterface');
+        $serviceManager = $this->getMockBuilder('\Zend\ServiceManager\ServiceLocatorInterface')->getMock();
         $serviceManager
             ->expects($this->any())
             ->method('has')

--- a/test/Factory/NamedOAuth2ServerFactoryTest.php
+++ b/test/Factory/NamedOAuth2ServerFactoryTest.php
@@ -21,7 +21,7 @@ class NamedOAuth2ServerFactoryTest extends TestCase
 
     public function setUpConfig($services)
     {
-        $services->setService('Config', [
+        $services->setService('config', [
             'zf-oauth2' => [
                 'storage' => 'ZFTest\OAuth2\TestAsset\MockAdapter',
                 'grant_types' => [

--- a/test/Factory/OAuth2ServerFactoryTest.php
+++ b/test/Factory/OAuth2ServerFactoryTest.php
@@ -31,7 +31,7 @@ class OAuth2ServerFactoryTest extends TestCase
 
     protected function mockConfig($services)
     {
-        $services->setService('Config', $this->getOAuth2Options());
+        $services->setService('config', $this->getOAuth2Options());
         return $services;
     }
 
@@ -143,7 +143,7 @@ class OAuth2ServerFactoryTest extends TestCase
         ];
 
         $services = new ServiceManager();
-        $services->setService('Config', $options);
+        $services->setService('config', $options);
 
         $config = [
             'adapter' => 'pdo',

--- a/test/Identity/IdentityPluginTest.php
+++ b/test/Identity/IdentityPluginTest.php
@@ -13,7 +13,7 @@ class IdentityPluginTest extends TestCase
     {
         $this->event = $event = new MvcEvent();
 
-        $controller = $this->getMock('Zend\Mvc\Controller\AbstractController');
+        $controller = $this->getMockBuilder('Zend\Mvc\Controller\AbstractController')->getMock();
         $controller->expects($this->any())
             ->method('getEvent')
             ->will($this->returnCallback(function () use ($event) {

--- a/test/MvcRouteListenerTest.php
+++ b/test/MvcRouteListenerTest.php
@@ -46,7 +46,4 @@ class MvcRouteListenerTest extends TestCase
 
         $this->assertTrue($found, $message);
     }
-
-
-
 }

--- a/test/MvcRouteListenerTest.php
+++ b/test/MvcRouteListenerTest.php
@@ -4,10 +4,14 @@ namespace ZFTest\MvcAuth;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\EventManager\EventManager;
+use Zend\EventManager\Test\EventListenerIntrospectionTrait;
+use Zend\Mvc\MvcEvent;
 use ZF\MvcAuth\MvcRouteListener;
 
 class MvcRouteListenerTest extends TestCase
 {
+    use EventListenerIntrospectionTrait;
+
     private $listener;
 
     public function setUp()
@@ -29,21 +33,47 @@ class MvcRouteListenerTest extends TestCase
         );
     }
 
-    public function assertListenerAtPriority($priority, $expectedCallback, $listeners, $message = '')
+    public function testRegistersAuthenticationListenerOnExpectedPriority()
     {
-        $found = false;
-        foreach ($listeners as $listener) {
-            $this->assertInstanceOf('Zend\Stdlib\CallbackHandler', $listener);
-            if ($listener->getMetadatum('priority') !== $priority) {
-                continue;
-            }
+        $this->listener->attach($this->events);
+        $this->assertListenerAtPriority(
+            [$this->listener, 'authentication'],
+            -50,
+            MvcEvent::EVENT_ROUTE,
+            $this->events
+        );
+    }
 
-            if ($listener->getCallback() === $expectedCallback) {
-                $found = true;
-                break;
-            }
-        }
+    public function testRegistersPostAuthenticationListenerOnExpectedPriority()
+    {
+        $this->listener->attach($this->events);
+        $this->assertListenerAtPriority(
+            [$this->listener, 'authenticationPost'],
+            -51,
+            MvcEvent::EVENT_ROUTE,
+            $this->events
+        );
+    }
 
-        $this->assertTrue($found, $message);
+    public function testRegistersAuthorizationListenerOnExpectedPriority()
+    {
+        $this->listener->attach($this->events);
+        $this->assertListenerAtPriority(
+            [$this->listener, 'authorization'],
+            -600,
+            MvcEvent::EVENT_ROUTE,
+            $this->events
+        );
+    }
+
+    public function testRegistersPostAuthorizationListenerOnExpectedPriority()
+    {
+        $this->listener->attach($this->events);
+        $this->assertListenerAtPriority(
+            [$this->listener, 'authorizationPost'],
+            -601,
+            MvcEvent::EVENT_ROUTE,
+            $this->events
+        );
     }
 }

--- a/test/RouteMatchFactoryTrait.php
+++ b/test/RouteMatchFactoryTrait.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\MvcAuth;
+
+use Zend\Mvc\Router\RouteMatch as V2RouteMatch;
+use Zend\Router\RouteMatch;
+
+trait RouteMatchFactoryTrait
+{
+    /**
+     * Create and return a version-specific RouteMatch instance.
+     *
+     * @param array $params
+     * @return RouteMatch|V2RouteMatch
+     */
+    public function createRouteMatch(array $params = [])
+    {
+        $class = class_exists(V2RouteMatch::class) ? V2RouteMatch::class : RouteMatch::class;
+        return new $class($params);
+    }
+}


### PR DESCRIPTION
This patch builds on #114 to do the following:

- Ensure all factories will work with both the v2 and v3 releases of zend-servicemanager.
- Ensures typehints against zend-router components are performed in such a way that they will also work with zend-mvc v2 routing classes.
- Moves the `Module` class into the `src/` tree, where it belongs.
- Exposes the component as a ZF module, for installation with zend-component-installer.
- Ensures tests will work against both major versions of all components.