### PR TITLE
Ensure events are triggered correctly.

### DIFF
--- a/src/MvcRouteListener.php
+++ b/src/MvcRouteListener.php
@@ -76,12 +76,13 @@ class MvcRouteListener extends AbstractListenerAggregate
         }
 
         $mvcAuthEvent = $this->mvcAuthEvent;
-        $responses    = $this->events->trigger($mvcAuthEvent::EVENT_AUTHENTICATION, $mvcAuthEvent, function ($r) {
+        $mvcAuthEvent->setName($mvcAuthEvent::EVENT_AUTHENTICATION);
+        $responses    = $this->events->triggerEventUntil(function ($r) {
             return ($r instanceof Identity\IdentityInterface
                 || $r instanceof Result
                 || $r instanceof Response
             );
-        });
+        }, $mvcAuthEvent);
 
         $result  = $responses->last();
         $storage = $this->authentication->getStorage();
@@ -148,13 +149,13 @@ class MvcRouteListener extends AbstractListenerAggregate
             return;
         }
 
-        $responses = $this->events->trigger(
-            MvcAuthEvent::EVENT_AUTHENTICATION_POST,
-            $this->mvcAuthEvent,
-            function ($r) {
-                return ($r instanceof Response);
-            }
-        );
+        $mvcAuthEvent = $this->mvcAuthEvent;
+        $mvcAuthEvent->setName($mvcAuthEvent::EVENT_AUTHENTICATION_POST);
+
+        $responses = $this->events->triggerEventUntil(function ($r) {
+            return ($r instanceof Response);
+        }, $mvcAuthEvent);
+
         return $responses->last();
     }
 
@@ -172,14 +173,17 @@ class MvcRouteListener extends AbstractListenerAggregate
             return;
         }
 
-        $responses = $this->events->trigger(MvcAuthEvent::EVENT_AUTHORIZATION, $this->mvcAuthEvent, function ($r) {
+        $mvcAuthEvent = $this->mvcAuthEvent;
+        $mvcAuthEvent->setName($mvcAuthEvent::EVENT_AUTHORIZATION);
+
+        $responses = $this->events->triggerEventUntil(function ($r) {
             return (is_bool($r) || $r instanceof Response);
-        });
+        }, $mvcAuthEvent);
 
         $result = $responses->last();
 
         if (is_bool($result)) {
-            $this->mvcAuthEvent->setIsAuthorized($result);
+            $mvcAuthEvent->setIsAuthorized($result);
             return;
         }
 
@@ -202,9 +206,13 @@ class MvcRouteListener extends AbstractListenerAggregate
             return;
         }
 
-        $responses = $this->events->trigger(MvcAuthEvent::EVENT_AUTHORIZATION_POST, $this->mvcAuthEvent, function ($r) {
+        $mvcAuthEvent = $this->mvcAuthEvent;
+        $mvcAuthEvent->setName($mvcAuthEvent::EVENT_AUTHORIZATION_POST);
+
+        $responses = $this->events->triggerEventUntil(function ($r) {
             return ($r instanceof Response);
-        });
+        }, $mvcAuthEvent);
+
         return $responses->last();
     }
 }

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -51,7 +51,7 @@ class ModuleTest extends TestCase
 
         // zend-servicemanager v2
         $servicesConfig = new ServiceManagerConfig($config['service_manager']);
-        $services = new ServiceManager($servicesConfig);
+        return new ServiceManager($servicesConfig);
     }
 
     public function testOnBootstrapReturnsEarlyForNonHttpEvents()


### PR DESCRIPTION
Events were being triggered using the legacy argument overloading from the zend-eventmanager v2 series, causing issues when used with v3 releases. This patch updates the code to do the following:

- set the event name in the `MvcAuthEvent` instance
- call `triggerEventUntil($callback, $mvcAuthEvent)`

This approach will work with both the minimum supported zend-eventmanager version, as well as v3 releases.