### PR TITLE
Ensure ACL rules work when dash is used for namespace separator in definitions

### DIFF
--- a/src/Factory/AclAuthorizationFactory.php
+++ b/src/Factory/AclAuthorizationFactory.php
@@ -94,6 +94,10 @@ class AclAuthorizationFactory implements FactoryInterface
      */
     protected function createAclConfigFromPrivileges($controllerService, array $privileges, &$aclConfig, $denyByDefault)
     {
+        // Normalize the controller service name.
+        // zend-mvc will always pass the name using namespace seprators, but
+        // the admin may write the name using dash seprators.
+        $controllerService = strtr($controllerService, '-', '\\');
         if (isset($privileges['actions'])) {
             foreach ($privileges['actions'] as $action => $methods) {
                 $action = lcfirst($action);


### PR DESCRIPTION
The Apigility Admin UI/API currently uses dash separators when defining ACL rules. This can lead to issues with the ACLs generated, as zend-mvc always uses namespace separators. This change ensures that the rules are correctly populated in the ACL during creation.

Another patch will be issued against zf-apigility-admin to ensure namespace separators are used in the future; in the meantime, this patch ensures zf-mvc-auth will work correctly.