### PR TITLE
Removed redundant empty test

### DIFF
--- a/test/Factory/AclAuthorizationFactoryTest.php
+++ b/test/Factory/AclAuthorizationFactoryTest.php
@@ -253,8 +253,4 @@ class AclAuthorizationFactoryTest extends TestCase
         $this->assertInstanceOf('ZF\MvcAuth\Authorization\AclAuthorization', $acl);
         $this->assertFalse($acl->isAllowed('guest', 'Foo\Bar\RpcController::do', 'POST'));
     }
-
-    public function testNormalizesControllerServiceNames()
-    {
-    }
 }


### PR DESCRIPTION
Removed redundant empty test added in [release 1.4.3](https://github.com/zfcampus/zf-mvc-auth/compare/1.4.2...1.4.3#diff-4c9ccd9d46fae86ea0f010d665fe0ecdR257)