### PR TITLE
fix hitting database twice bu storing the requested token value.

### DIFF
--- a/src/Authentication/OAuth2Adapter.php
+++ b/src/Authentication/OAuth2Adapter.php
@@ -145,27 +145,40 @@ class OAuth2Adapter extends AbstractAdapter
             $request->getHeaders()->toArray()
         );
 
+        $token = $this->oauth2Server->verifyResourceRequest($oauth2request);
+
         // Failure to validate
-        if (! $this->oauth2Server->verifyResourceRequest($oauth2request)) {
-            $oauth2Response = $this->oauth2Server->getResponse();
-            $status = $oauth2Response->getStatusCode();
-
-            // 401 or 403 mean invalid credentials or unauthorized scopes; report those.
-            if (in_array($status, [401, 403], true) && null !== $oauth2Response->getParameter('error')) {
-                return $this->mergeOAuth2Response($status, $response, $oauth2Response);
-            }
-
-            // Merge in any headers; typically sets a WWW-Authenticate header.
-            $this->mergeOAuth2ResponseHeaders($response, $oauth2Response->getHttpHeaders());
-
-            // Otherwise, no credentials were present at all, so we just return a guest identity.
-            return new Identity\GuestIdentity();
+        if (! $token) {
+            return $this->processInvalidToken($response);
         }
 
-        $token    = $this->oauth2Server->getAccessTokenData($oauth2request);
         $identity = new Identity\AuthenticatedIdentity($token);
         $identity->setName($token['user_id']);
+
         return $identity;
+    }
+
+    /**
+     * Handle a invalid Token.
+     *
+     * @param $response
+     * @return Response|Identity\GuestIdentity
+     */
+    private function processInvalidToken($response)
+    {
+        $oauth2Response = $this->oauth2Server->getResponse();
+        $status = $oauth2Response->getStatusCode();
+
+        // 401 or 403 mean invalid credentials or unauthorized scopes; report those.
+        if (in_array($status, [401, 403], true) && null !== $oauth2Response->getParameter('error')) {
+            return $this->mergeOAuth2Response($status, $response, $oauth2Response);
+        }
+
+        // Merge in any headers; typically sets a WWW-Authenticate header.
+        $this->mergeOAuth2ResponseHeaders($response, $oauth2Response->getHttpHeaders());
+
+        // Otherwise, no credentials were present at all, so we just return a guest identity.
+        return new Identity\GuestIdentity();
     }
 
     /**

--- a/src/Authentication/OAuth2Adapter.php
+++ b/src/Authentication/OAuth2Adapter.php
@@ -145,7 +145,7 @@ class OAuth2Adapter extends AbstractAdapter
             $request->getHeaders()->toArray()
         );
 
-        $token = $this->oauth2Server->verifyResourceRequest($oauth2request);
+        $token = $this->oauth2Server->getAccessTokenData($oauth2request);
 
         // Failure to validate
         if (! $token) {


### PR DESCRIPTION
- fix hitting database twice bystoring the requested token value.
- cleanup code a bit. breakup invalid token request to custom method.

in regards to:
https://github.com/zfcampus/zf-mvc-auth/issues/135